### PR TITLE
Update indentation settings: tabSize = 4, insertSpaces = true

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,8 +152,8 @@
 		"configurationDefaults": {
 			"[macaulay2]": {
 				"editor.detectIndentation": false,
-				"editor.insertSpaces": false,
-				"editor.tabSize": 8
+				"editor.insertSpaces": true,
+				"editor.tabSize": 4
 			}
 		},
 		"keybindings": [

--- a/package.json
+++ b/package.json
@@ -153,7 +153,8 @@
 			"[macaulay2]": {
 				"editor.detectIndentation": false,
 				"editor.insertSpaces": true,
-				"editor.tabSize": 4
+				"editor.tabSize": 8,
+				"editor.indentSize": 4
 			}
 		},
 		"keybindings": [


### PR DESCRIPTION
Following discussion in zulip: [#Workshop: 2026 Atlanta > VSCode](https://macaulay2.zulipchat.com/#narrow/channel/597423-Workshop.3A-2026-Atlanta/topic/VSCode/with/597168414)

These settings chosen based on comments: "the vast majority of current M2 code is written with 4-space indent" and "The best approach might be to setup both emacs and vscode to not enter tabs in M2 code to avoid confusion."