### PR TITLE
Look up the language server executable at most once

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Use `F12` or run **Macaulay2: Start M2 REPL** from the Command Palette to start 
 - An integrated Macaulay2 REPL in a VS Code webview.
 - Terminal-backed evaluation in a standard VS Code terminal through a separate command/keybinding.
 - Automatic `M2` executable detection on macOS and Windows, including WSL installs on Windows, with a manual override when needed.
-- Language server support via `M2-language-server` for additional editor features when installed.
+- Language server support via `M2-language-server` for additional editor features when installed, found automatically or pointed at with a setting.
 
 ![Syntax highlighting](https://user-images.githubusercontent.com/186528/54696704-990e3480-4b2c-11e9-9376-3106aa64d618.png)
 
@@ -62,6 +62,7 @@ There is no REPL target setting. To send evaluation to the terminal from a keybi
 | `macaulay2.webviewTopLevelMode` | `webapp` | Choose the webview REPL top-level output mode: `webapp` or `standard`. |
 | `macaulay2.webviewMatrixKatexMaxEntries` | `2500` | Maximum matrix entries the webview REPL renders with KaTeX. Larger matrices use Macaulay2 net output, matching `topLevelMode = Standard`. |
 | `macaulay2.enableLanguageServer` | `true` | Enable the Macaulay2 Language Server. Requires `M2-language-server` to be installed; skipped silently if not found. |
+| `macaulay2.languageServerPath` | `""` | Absolute path to the `M2-language-server` executable. Leave empty to detect it automatically. |
 
 ## Regenerating the grammars
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ There is no REPL target setting. To send evaluation to the terminal from a keybi
 | `macaulay2.webviewTopLevelMode` | `webapp` | Choose the webview REPL top-level output mode: `webapp` or `standard`. |
 | `macaulay2.webviewMatrixKatexMaxEntries` | `2500` | Maximum matrix entries the webview REPL renders with KaTeX. Larger matrices use Macaulay2 net output, matching `topLevelMode = Standard`. |
 | `macaulay2.enableLanguageServer` | `true` | Enable the Macaulay2 Language Server. Requires `M2-language-server` to be installed; skipped silently if not found. |
-| `macaulay2.languageServerPath` | `""` | Absolute path to the `M2-language-server` executable. Leave empty to detect it automatically. On Windows, a Unix path is launched through the default WSL distribution. |
+| `macaulay2.languageServerPath` | `""` | Absolute path to the `M2-language-server` executable for the entire VS Code window. Leave empty to detect it automatically. Use User or Remote settings for machine-local paths. On Windows, a Unix path is launched through the default WSL distribution. |
 
 ## Regenerating the grammars
 

--- a/esbuild.js
+++ b/esbuild.js
@@ -17,6 +17,7 @@ async function build() {
     const testCtx = await esbuild.context({
       ...baseConfig,
       entryPoints: {
+        "client.test": "src/backend/test/client.test.ts",
         "extension.test": "src/backend/test/extension.test.ts",
         "grammar.test": "src/backend/test/grammar.test.ts",
         "outputLayout.test": "src/webview/test/outputLayout.test.ts",
@@ -27,7 +28,13 @@ async function build() {
       target: "node18",
       // vscode-oniguruma loads onig.wasm relative to its own location, so it
       // has to stay in node_modules rather than being bundled.
-      external: ["vscode", "vscode-textmate", "vscode-oniguruma"],
+      external: [
+        "vscode",
+        "vscode-textmate",
+        "vscode-oniguruma",
+        // The test server resolves its own JSON-RPC module in a child process.
+        "vscode-jsonrpc/package.json",
+      ],
     });
 
     if (watch) {

--- a/package.json
+++ b/package.json
@@ -111,6 +111,12 @@
 					"description": "Enable the Macaulay2 Language Server for enhanced language support (hover, signature help, etc.). Requires M2-language-server to be installed.",
 					"scope": "window"
 				},
+				"macaulay2.languageServerPath": {
+					"type": "string",
+					"default": "",
+					"description": "Absolute path to the M2-language-server executable. Leave empty to detect it automatically.",
+					"scope": "window"
+				},
 				"macaulay2.executablePath": {
 					"type": "string",
 					"default": "",

--- a/package.json
+++ b/package.json
@@ -26,32 +26,39 @@
 		"commands": [
 			{
 				"command": "macaulay2.startREPL",
-				"title": "Start M2 REPL"
+				"title": "Start M2 REPL",
+				"category": "Macaulay2"
 			},
 			{
 				"command": "macaulay2.startTerminal",
-				"title": "Start M2 Terminal"
+				"title": "Start M2 Terminal",
+				"category": "Macaulay2"
 			},
 			{
 				"command": "macaulay2.sendToWebview",
-				"title": "Send Line or Selection to Macaulay2 Webview"
+				"title": "Send Line or Selection to Macaulay2 Webview",
+				"category": "Macaulay2"
 			},
 			{
 				"command": "macaulay2.sendToTerminal",
-				"title": "Send Line or Selection to Macaulay2 Terminal"
+				"title": "Send Line or Selection to Macaulay2 Terminal",
+				"category": "Macaulay2"
 			},
 			{
 				"command": "macaulay2.runFile",
 				"title": "Run Macaulay2 File",
+				"category": "Macaulay2",
 				"icon": "$(play)"
 			},
 			{
 				"command": "macaulay2.interruptREPL",
-				"title": "Interrupt M2 Computation"
+				"title": "Interrupt M2 Computation",
+				"category": "Macaulay2"
 			},
 			{
 				"command": "macaulay2.selectExecutablePath",
-				"title": "Select M2 Executable"
+				"title": "Select M2 Executable",
+				"category": "Macaulay2"
 			},
 			{
 				"command": "macaulay2.restartLanguageServer",

--- a/package.json
+++ b/package.json
@@ -114,8 +114,9 @@
 				"macaulay2.languageServerPath": {
 					"type": "string",
 					"default": "",
-					"description": "Absolute path to the M2-language-server executable. Leave empty to detect it automatically. On Windows, a Unix path is launched through the default WSL distribution.",
-					"scope": "machine-overridable"
+					"description": "Absolute path to the M2-language-server executable for this VS Code window. Leave empty to detect it automatically. Use User or Remote settings for machine-local paths. On Windows, a Unix path is launched through the default WSL distribution.",
+					"scope": "window",
+					"ignoreSync": true
 				},
 				"macaulay2.executablePath": {
 					"type": "string",

--- a/src/backend/client.ts
+++ b/src/backend/client.ts
@@ -13,6 +13,9 @@
 //
 
 import {
+  CloseAction,
+  ErrorAction,
+  ErrorHandler,
   Executable,
   LanguageClient,
   LanguageClientOptions,
@@ -98,14 +101,138 @@ function terminateChildProcess(child: ChildProcess) {
   }
 }
 
-class CancellableLanguageClient extends LanguageClient {
+export class CancellableLanguageClient extends LanguageClient {
   private cancellationRequested = false;
   private ownedServerProcess: ChildProcess | undefined;
+  private pendingStartup: Promise<void> | undefined;
+  private readonly pendingWrites = new Set<Promise<void>>();
+
+  constructor(
+    id: string,
+    name: string,
+    serverOptions: ServerOptions,
+    clientOptions: LanguageClientOptions,
+  ) {
+    super(id, name, serverOptions, {
+      ...clientOptions,
+      // Let start() reject to the controller instead of showing a separate
+      // initialization notification (including during intentional cancellation).
+      initializationFailedHandler: () => false,
+    });
+  }
+
+  start(): Promise<void> {
+    if (this.cancellationRequested) {
+      return Promise.reject(new Error("Language server start was cancelled."));
+    }
+    const startup = super.start();
+    this.pendingStartup = startup;
+    return startup.finally(async () => {
+      if (this.pendingStartup === startup) this.pendingStartup = undefined;
+      if (this.cancellationRequested && this.isRunning()) {
+        // A transport can finish starting after the bounded stop below has
+        // returned. Its registrations still need a final graceful cleanup.
+        try {
+          await super.stop();
+        } catch {
+          this.terminateServerProcess();
+        }
+      }
+    });
+  }
+
+  async stop(timeout?: number): Promise<void> {
+    const startup = this.pendingStartup;
+    if (startup) {
+      // v9 reports Running before its initialized notification has finished
+      // writing. Stopping at that point clears features too early: initialize
+      // can still install providers and listeners afterwards.
+      let graceHandle: ReturnType<typeof setTimeout> | undefined;
+      try {
+        const settled = await Promise.race([
+          startup.then(
+            () => true,
+            () => true,
+          ),
+          new Promise<boolean>((resolve) => {
+            graceHandle = setTimeout(
+              () => resolve(false),
+              PROCESS_TERMINATION_GRACE_MILLISECONDS,
+            );
+          }),
+        ]);
+        if (!settled) {
+          this.terminateServerProcess();
+          return;
+        }
+      } finally {
+        if (graceHandle !== undefined) clearTimeout(graceHandle);
+      }
+
+      // doInitialize also calls stop() without observing its promise when
+      // initialization fails. A failed or still-pending start cannot use the
+      // library's normal stop API; disposal owns forced process cleanup.
+      if (!this.isRunning()) return;
+    }
+
+    try {
+      await super.stop(timeout);
+    } catch (error) {
+      if (!this.cancellationRequested) throw error;
+      this.terminateServerProcess();
+    }
+  }
+
+  createDefaultErrorHandler(maxRestartCount?: number): ErrorHandler {
+    const handler = super.createDefaultErrorHandler(maxRestartCount);
+    return {
+      error: (error, message, count) =>
+        this.cancellationRequested
+          ? { action: ErrorAction.Continue, handled: true }
+          : handler.error(error, message, count),
+      closed: async () => {
+        if (!this.cancellationRequested) return handler.closed();
+
+        // The base close handler has already disposed the connection, allowing
+        // initialize to reject. Wait before it clears _onStart, otherwise v9
+        // can orphan that rejected promise and attempt an unwanted restart.
+        await this.pendingStartup?.catch(() => {});
+        return { action: CloseAction.DoNotRestart, handled: true };
+      },
+    };
+  }
+
+  error(message: string, data?: unknown, showNotification?: boolean | "force") {
+    super.error(
+      message,
+      data,
+      this.cancellationRequested ? false : showNotification,
+    );
+  }
 
   cancelStart() {
     this.cancellationRequested = true;
     this.captureServerProcess();
-    this.terminateServerProcess();
+    // Once initialize has replied, allow the initialized write to finish so
+    // stop can clean up its registrations. A hung handshake is killed now;
+    // a hung initialized write is killed by stop's bounded wait above.
+    if (!this.pendingStartup || !this.isRunning()) {
+      this.terminateAfterWrites();
+    }
+  }
+
+  private terminateAfterWrites() {
+    if (this.pendingWrites.size === 0) {
+      this.terminateServerProcess();
+      return;
+    }
+
+    // JSON-RPC 8 can leak a rejection if the initialize request's write fails.
+    // Let queued bytes flush before closing the pipes; stop's grace period
+    // still bounds termination if a write never completes.
+    void Promise.allSettled([...this.pendingWrites]).then(() => {
+      this.terminateAfterWrites();
+    });
   }
 
   protected async createMessageTransports(
@@ -118,6 +245,14 @@ class CancellableLanguageClient extends LanguageClient {
         this.terminateServerProcess();
         throw new Error("Language server start was cancelled.");
       }
+      const write = transports.writer.write.bind(transports.writer);
+      transports.writer.write = (message) => {
+        const pending = write(message);
+        this.pendingWrites.add(pending);
+        const remove = () => this.pendingWrites.delete(pending);
+        void pending.then(remove, remove);
+        return pending;
+      };
       return transports;
     } catch (error) {
       this.captureServerProcess();
@@ -227,23 +362,21 @@ export function manageLanguageClient(
       startPending = true;
       try {
         const result = client.start();
-        startCleanup = Promise.resolve(result)
-          .then(
-            async () => {
-              if (!disposalRequested) return;
-              try {
-                await client.stop();
-              } catch {
-                // dispose(0) already scheduled forced process termination.
-              }
-            },
-            () => {
-              // The controller reports the original start failure.
-            },
-          )
-          .finally(() => {
+        startCleanup = Promise.resolve(result).then(
+          async () => {
             startPending = false;
-          });
+            if (!disposalRequested) return;
+            try {
+              await client.stop();
+            } catch {
+              // dispose(0) already scheduled forced process termination.
+            }
+          },
+          () => {
+            startPending = false;
+            // The controller reports the original start failure.
+          },
+        );
         return result;
       } catch (error) {
         startPending = false;
@@ -251,6 +384,9 @@ export function manageLanguageClient(
       }
     },
     async stop() {
+      // Mark cancellation before stop waits for initialize. Waiting until
+      // dispose would leave a hung handshake blocking the controller's queue.
+      if (startPending) client.cancelStart?.();
       try {
         await client.stop();
       } catch (error) {

--- a/src/backend/client.ts
+++ b/src/backend/client.ts
@@ -16,30 +16,331 @@ import {
   Executable,
   LanguageClient,
   LanguageClientOptions,
+  MessageTransports,
   ServerOptions,
 } from "vscode-languageclient/node";
+import { execFileSync, spawnSync } from "child_process";
+import type { ChildProcess } from "child_process";
+import { window } from "vscode";
+import type { OutputChannel, ViewColumn } from "vscode";
 
 import { CommandExecutableResolution } from "./executablePath";
+import type { LanguageServerClient } from "./languageServer";
 
-const clientOptions: LanguageClientOptions = {
-  documentSelector: [
-    { scheme: "file", language: "macaulay2" },
-    { scheme: "untitled", language: "macaulay2" },
-  ],
-};
+interface DisposableResource {
+  dispose(): unknown;
+}
+
+interface RawLanguageClient {
+  readonly diagnostics: DisposableResource | undefined;
+  start(): Thenable<void>;
+  stop(timeout?: number): Thenable<void>;
+  dispose(timeout?: number): Thenable<void>;
+  cancelStart?(): void;
+}
+
+const PROCESS_TERMINATION_GRACE_MILLISECONDS = 2_500;
+
+function terminatePosixProcessTree(pid: number, visited = new Set<number>()) {
+  if (visited.has(pid)) return;
+  visited.add(pid);
+
+  try {
+    const descendants = spawnSync("pgrep", ["-P", pid.toString()], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 1_000,
+    });
+    if (typeof descendants.stdout === "string") {
+      for (const line of descendants.stdout.split(/\s+/)) {
+        if (!/^\d+$/.test(line)) continue;
+        terminatePosixProcessTree(Number(line), visited);
+      }
+    }
+  } catch {
+    // Killing the known process is still better than abandoning cleanup when
+    // process enumeration is unavailable.
+  }
+
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    // A process can exit while its tree is being enumerated.
+  }
+}
+
+function terminateChildProcess(child: ChildProcess) {
+  if (
+    child.pid === undefined ||
+    child.exitCode !== null ||
+    child.signalCode !== null
+  ) {
+    return;
+  }
+
+  try {
+    if (process.platform === "win32") {
+      execFileSync("taskkill", ["/T", "/F", "/PID", child.pid.toString()], {
+        stdio: "ignore",
+        timeout: 2_000,
+      });
+    } else if (process.platform === "darwin" || process.platform === "linux") {
+      terminatePosixProcessTree(child.pid);
+    } else {
+      child.kill("SIGKILL");
+    }
+  } catch {
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // The process may already have exited between the checks above.
+    }
+  }
+}
+
+class CancellableLanguageClient extends LanguageClient {
+  private cancellationRequested = false;
+  private ownedServerProcess: ChildProcess | undefined;
+
+  cancelStart() {
+    this.cancellationRequested = true;
+    this.captureServerProcess();
+    this.terminateServerProcess();
+  }
+
+  protected async createMessageTransports(
+    encoding: string,
+  ): Promise<MessageTransports> {
+    try {
+      const transports = await super.createMessageTransports(encoding);
+      this.captureServerProcess();
+      if (this.cancellationRequested) {
+        this.terminateServerProcess();
+        throw new Error("Language server start was cancelled.");
+      }
+      return transports;
+    } catch (error) {
+      this.captureServerProcess();
+      if (this.cancellationRequested) this.terminateServerProcess();
+      throw error;
+    }
+  }
+
+  private captureServerProcess() {
+    const spawned = (this as unknown as { _serverProcess?: ChildProcess })
+      ._serverProcess;
+    if (!spawned || this.ownedServerProcess === spawned) return;
+
+    this.ownedServerProcess = spawned;
+    spawned.once("exit", () => {
+      if (this.ownedServerProcess === spawned) {
+        this.ownedServerProcess = undefined;
+      }
+    });
+  }
+
+  private terminateServerProcess() {
+    if (this.ownedServerProcess) {
+      terminateChildProcess(this.ownedServerProcess);
+    }
+  }
+}
+
+class GuardedOutputChannel implements OutputChannel {
+  readonly name: string;
+  private closed = false;
+
+  constructor(private readonly channel: OutputChannel) {
+    this.name = channel.name;
+  }
+
+  append(value: string) {
+    if (!this.closed) this.channel.append(value);
+  }
+
+  appendLine(value: string) {
+    if (!this.closed) this.channel.appendLine(value);
+  }
+
+  replace(value: string) {
+    if (!this.closed) this.channel.replace(value);
+  }
+
+  clear() {
+    if (!this.closed) this.channel.clear();
+  }
+
+  show(preserveFocus?: boolean): void;
+  show(column?: ViewColumn, preserveFocus?: boolean): void;
+  show(columnOrPreserveFocus?: ViewColumn | boolean, preserveFocus?: boolean) {
+    if (this.closed) return;
+    if (typeof columnOrPreserveFocus === "number") {
+      this.channel.show(columnOrPreserveFocus, preserveFocus);
+    } else {
+      this.channel.show(columnOrPreserveFocus);
+    }
+  }
+
+  hide() {
+    if (!this.closed) this.channel.hide();
+  }
+
+  dispose() {
+    if (this.closed) return;
+    this.closed = true;
+    this.channel.dispose();
+  }
+}
+
+export function createGuardedOutputChannel(
+  channel: OutputChannel,
+): OutputChannel {
+  return new GuardedOutputChannel(channel);
+}
+
+function disposeQuietly(resource: DisposableResource | undefined) {
+  try {
+    resource?.dispose();
+  } catch {
+    // Cleanup is best effort, and must not hide the lifecycle error that led
+    // here.
+  }
+}
+
+// vscode-languageclient 9 rejects dispose() while a client is Starting or
+// StartFailed, before releasing the diagnostic collection and output channel.
+// Own those resources outside the client so every failed or cancelled start
+// has an idempotent cleanup path.
+export function manageLanguageClient(
+  client: RawLanguageClient,
+  outputChannel: DisposableResource,
+  processTerminationGraceMilliseconds = PROCESS_TERMINATION_GRACE_MILLISECONDS,
+): LanguageServerClient {
+  let disposal: Promise<void> | undefined;
+  let disposalRequested = false;
+  let startPending = false;
+  let startCleanup: Promise<void> | undefined;
+  let stopFailed = false;
+
+  return {
+    start() {
+      startPending = true;
+      try {
+        const result = client.start();
+        startCleanup = Promise.resolve(result)
+          .then(
+            async () => {
+              if (!disposalRequested) return;
+              try {
+                await client.stop();
+              } catch {
+                // dispose(0) already scheduled forced process termination.
+              }
+            },
+            () => {
+              // The controller reports the original start failure.
+            },
+          )
+          .finally(() => {
+            startPending = false;
+          });
+        return result;
+      } catch (error) {
+        startPending = false;
+        throw error;
+      }
+    },
+    async stop() {
+      try {
+        await client.stop();
+      } catch (error) {
+        stopFailed = true;
+        throw error;
+      }
+    },
+    dispose() {
+      disposalRequested = true;
+      if (!disposal) {
+        client.cancelStart?.();
+        const diagnostics = client.diagnostics;
+        const pendingStart = startPending ? startCleanup : undefined;
+        disposal = (async () => {
+          let rawDisposeFailed = false;
+          try {
+            // Zero makes the library's own shutdown race return immediately.
+            // Its Node adapter still schedules termination of a child process
+            // that was created by an incomplete start.
+            await client.dispose(0);
+          } catch {
+            // StartFailed and Starting are expected to reject here.
+            rawDisposeFailed = true;
+          }
+
+          if (rawDisposeFailed || stopFailed || pendingStart) {
+            // The Node client schedules forced child termination two seconds
+            // after stop() rejects in Starting state.  Wait for a late start
+            // to be stopped, or just beyond that bounded termination window,
+            // before a replacement can launch.
+            let graceHandle: ReturnType<typeof setTimeout> | undefined;
+            const grace = new Promise<void>((resolve) => {
+              graceHandle = setTimeout(
+                resolve,
+                Math.max(0, processTerminationGraceMilliseconds),
+              );
+            });
+            if (rawDisposeFailed || stopFailed) {
+              // StartFailed settles its start promise before dispose() gets
+              // here, but its child termination is still only scheduled.  Do
+              // not let that rejection shorten the process grace period.
+              await grace;
+            } else if (pendingStart) {
+              await Promise.race([pendingStart, grace]);
+            }
+            if (graceHandle !== undefined) clearTimeout(graceHandle);
+          }
+
+          // A normal stop clears diagnostics itself.  A failed start leaves
+          // the same collection installed, so release it explicitly.
+          if (client.diagnostics === diagnostics) {
+            disposeQuietly(diagnostics);
+          }
+          disposeQuietly(outputChannel);
+        })();
+      }
+
+      return disposal;
+    },
+  };
+}
 
 export function createLanguageClient(
   resolution: CommandExecutableResolution,
-): LanguageClient {
+): LanguageServerClient {
   const serverOptions: Executable = {
     command: resolution.executablePath,
     args: resolution.args,
   };
-
-  return new LanguageClient(
-    "macaulay2-language-server",
-    "Macaulay2 Language Server",
-    serverOptions as ServerOptions,
-    clientOptions,
+  const outputChannel = createGuardedOutputChannel(
+    window.createOutputChannel("Macaulay2 Language Server"),
   );
+  const clientOptions: LanguageClientOptions = {
+    documentSelector: [
+      { scheme: "file", language: "macaulay2" },
+      { scheme: "untitled", language: "macaulay2" },
+    ],
+    outputChannel,
+  };
+
+  try {
+    const client = new CancellableLanguageClient(
+      "macaulay2-language-server",
+      "Macaulay2 Language Server",
+      serverOptions as ServerOptions,
+      clientOptions,
+    );
+    return manageLanguageClient(client, outputChannel);
+  } catch (error) {
+    disposeQuietly(outputChannel);
+    throw error;
+  }
 }

--- a/src/backend/client.ts
+++ b/src/backend/client.ts
@@ -1,3 +1,17 @@
+//
+// Construction of the Macaulay2 language client.
+//
+// This module is loaded through a dynamic import, so that the extension does
+// not pull vscode-languageclient into activation for the many users who have
+// no M2-language-server installed, or who have turned the setting off.
+//
+// Each client is built from one resolution and never mutated afterwards.  The
+// server options are read when the client starts, so mutating them in place
+// happens to work, but it leaves the client's configuration and the executable
+// it was resolved from able to drift apart.  Building a fresh client when the
+// resolution changes keeps them the same thing.
+//
+
 import {
   Executable,
   LanguageClient,
@@ -5,9 +19,7 @@ import {
   ServerOptions,
 } from "vscode-languageclient/node";
 
-const serverOptions: Executable = {
-  command: "M2-language-server",
-};
+import { CommandExecutableResolution } from "./executablePath";
 
 const clientOptions: LanguageClientOptions = {
   documentSelector: [
@@ -16,14 +28,18 @@ const clientOptions: LanguageClientOptions = {
   ],
 };
 
-export function configureLanguageServer(command: string, args?: string[]) {
-  serverOptions.command = command;
-  serverOptions.args = args;
-}
+export function createLanguageClient(
+  resolution: CommandExecutableResolution,
+): LanguageClient {
+  const serverOptions: Executable = {
+    command: resolution.executablePath,
+    args: resolution.args,
+  };
 
-export default new LanguageClient(
-  "macaulay2-language-server",
-  "Macaulay2 Language Server",
-  serverOptions as ServerOptions,
-  clientOptions,
-);
+  return new LanguageClient(
+    "macaulay2-language-server",
+    "Macaulay2 Language Server",
+    serverOptions as ServerOptions,
+    clientOptions,
+  );
+}

--- a/src/backend/executablePath.ts
+++ b/src/backend/executablePath.ts
@@ -24,40 +24,126 @@ export interface CommandExecutableResolution {
 
 export type M2LaunchArgsConfiguration = string | undefined;
 
+export interface CommandProbe {
+  resolution?: CommandExecutableResolution;
+  timedOut: boolean;
+}
+
+interface ShellProbe {
+  executablePath?: string;
+  timedOut: boolean;
+}
+
+export interface CachedCommandResolver {
+  // Returns the probe rather than just the resolution: callers that stop
+  // asking after a negative answer need to know whether it was conclusive.
+  resolve(): CommandProbe;
+  forget(): void;
+}
+
+// Every shell probe below runs synchronously on the extension host thread, so
+// none of them may wait indefinitely.  A login shell that sources nvm, conda,
+// or pyenv is routinely a few hundred milliseconds, and a misconfigured one can
+// block outright.  Same budget the WSL probes use.
+const shellProbeTimeoutMilliseconds = 5000;
+
+/**
+ * Resolve a command once and remember the answer, "not found" included.
+ *
+ * Resolution is expensive: on Windows it shells out to Cygwin bash and wsl.exe,
+ * and elsewhere it may spawn a login shell.  Callers driven by editor events
+ * would otherwise pay that cost on every tab switch, and the "not installed"
+ * case is the one that pays it every single time -- there is no successful
+ * lookup to stop the retries.
+ *
+ * A probe that timed out is deliberately *not* remembered.  The command may be
+ * installed behind a shell that was merely slow, and caching that answer would
+ * turn one unlucky probe into a session-long verdict.
+ *
+ * `forget` exists so an explicit user action can pick up an executable that was
+ * installed after the extension activated.
+ */
+export function createCachedCommandResolver(
+  command: string,
+  probe: (command: string) => CommandProbe = probeCommandExecutable,
+): CachedCommandResolver {
+  // The box distinguishes "looked, found nothing" from "not looked yet".
+  let cached: { probe: CommandProbe } | undefined;
+
+  return {
+    resolve() {
+      if (cached) {
+        return cached.probe;
+      }
+
+      const result = probe(command);
+      if (!result.resolution && result.timedOut) {
+        return result;
+      }
+
+      cached = { probe: result };
+      return result;
+    },
+    forget() {
+      cached = undefined;
+    },
+  };
+}
+
 export function resolveCommandExecutable(
   command: string,
 ): CommandExecutableResolution | undefined {
+  return probeCommandExecutable(command).resolution;
+}
+
+/**
+ * Resolve a command, reporting whether a shell probe ran out of time.
+ *
+ * A timeout is not the same answer as "not installed" -- the command may well
+ * be there behind a shell that was merely slow -- so callers that remember a
+ * negative result need to be able to decline to remember this one.
+ */
+export function probeCommandExecutable(command: string): CommandProbe {
   const fromPath = findCommandOnPath(command);
   if (fromPath) {
-    return { executablePath: fromPath, source: "PATH" };
+    return {
+      resolution: { executablePath: fromPath, source: "PATH" },
+      timedOut: false,
+    };
   }
 
   if (process.platform === "win32") {
     const fromCygwinShell = resolveCommandWithCygwinShell(command);
-    if (fromCygwinShell) {
+    if (fromCygwinShell.executablePath) {
       return {
-        executablePath: fromCygwinShell,
-        source: "Cygwin shell",
+        resolution: {
+          executablePath: fromCygwinShell.executablePath,
+          source: "Cygwin shell",
+        },
+        timedOut: false,
       };
     }
 
     const fromWsl = resolveCommandWithWsl(command);
     if (fromWsl) {
-      return fromWsl;
+      return { resolution: fromWsl, timedOut: false };
     }
 
-    return undefined;
+    return { timedOut: fromCygwinShell.timedOut };
   }
 
   const fromLoginShell = resolveCommandWithLoginShell(command);
-  if (fromLoginShell) {
+  if (fromLoginShell.executablePath) {
     return {
-      executablePath: fromLoginShell,
-      source: "login shell PATH",
+      resolution: {
+        executablePath: fromLoginShell.executablePath,
+        source: "login shell PATH",
+      },
+      timedOut: false,
     };
   }
 
-  return undefined;
+  return { timedOut: fromLoginShell.timedOut };
 }
 
 export function resolveM2Executable(
@@ -307,32 +393,32 @@ function resolveManualWslExecutable(
 }
 
 function resolveWithLoginShell(): string | undefined {
-  return resolveCommandWithLoginShell("M2");
+  return resolveCommandWithLoginShell("M2").executablePath;
 }
 
-function resolveCommandWithLoginShell(command: string): string | undefined {
+function resolveCommandWithLoginShell(command: string): ShellProbe {
   const shell = getEnv("SHELL");
   if (!shell || !path.isAbsolute(shell) || !fs.existsSync(shell)) {
-    return undefined;
+    return { timedOut: false };
   }
 
-  const resolved = runShellCommand(shell, [
-    "-l",
-    "-c",
-    `command -v ${quoteShellWord(command)}`,
-  ]);
-  if (resolved && isExecutableFile(resolved)) {
-    return resolved;
+  const result = runShellCommand(
+    shell,
+    ["-l", "-c", `command -v ${quoteShellWord(command)}`],
+    shellProbeTimeoutMilliseconds,
+  );
+  if (result.output && isExecutableFile(result.output)) {
+    return { executablePath: result.output, timedOut: false };
   }
 
-  return undefined;
+  return { timedOut: result.timedOut };
 }
 
 function resolveWithCygwinShell(): string | undefined {
-  return resolveCommandWithCygwinShell("M2");
+  return resolveCommandWithCygwinShell("M2").executablePath;
 }
 
-function resolveCommandWithCygwinShell(command: string): string | undefined {
+function resolveCommandWithCygwinShell(command: string): ShellProbe {
   const bashCandidates = [
     findCommandOnPath("bash"),
     ...getWindowsCandidateRoots().map((root) =>
@@ -340,22 +426,38 @@ function resolveCommandWithCygwinShell(command: string): string | undefined {
     ),
   ];
 
+  // The timeout bounds one spawn, and there can be a dozen candidates here, so
+  // budget the loop as a whole rather than letting the worst case add up.
+  const deadline = Date.now() + shellProbeTimeoutMilliseconds;
+
   for (const bashPath of dedupe(bashCandidates)) {
     if (!bashPath || !isExecutableFile(bashPath)) {
       continue;
     }
 
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      return { timedOut: true };
+    }
+
     const quotedCommand = quoteShellWord(command);
-    const resolved = runShellCommand(bashPath, [
-      "-lc",
-      `if command -v ${quotedCommand} >/dev/null 2>&1; then cygpath -wa "$(command -v ${quotedCommand})"; fi`,
-    ]);
-    if (resolved && isExecutableFile(resolved)) {
-      return resolved;
+    const result = runShellCommand(
+      bashPath,
+      [
+        "-lc",
+        `if command -v ${quotedCommand} >/dev/null 2>&1; then cygpath -wa "$(command -v ${quotedCommand})"; fi`,
+      ],
+      remaining,
+    );
+    if (result.output && isExecutableFile(result.output)) {
+      return { executablePath: result.output, timedOut: false };
+    }
+    if (result.timedOut) {
+      return { timedOut: true };
     }
   }
 
-  return undefined;
+  return { timedOut: false };
 }
 
 function resolveWithWsl(): M2ExecutableResolution | undefined {
@@ -380,10 +482,10 @@ function resolveCommandWithWsl(
     return undefined;
   }
 
-  const resolved = runShellCommand(
+  const resolved = runShellCommandOutput(
     wslPath,
     ["--exec", "sh", "-lc", `command -v ${quoteShellWord(command)}`],
-    5000,
+    shellProbeTimeoutMilliseconds,
   );
   const wslExecutablePath = normalizeShellOutputPath(resolved);
   if (!wslExecutablePath || !isUnixAbsolutePath(wslExecutablePath)) {
@@ -399,10 +501,10 @@ function resolveCommandWithWsl(
 
 function resolveWslDistroName(wslPath: string): string | undefined {
   const envDistroName = normalizeShellOutputPath(
-    runShellCommand(
+    runShellCommandOutput(
       wslPath,
       ["--exec", "sh", "-lc", 'printf "%s" "$WSL_DISTRO_NAME"'],
-      5000,
+      shellProbeTimeoutMilliseconds,
     ),
   );
   if (envDistroName) {
@@ -421,10 +523,10 @@ function resolveWslWindowsPath(
   filePath: string,
 ): string | undefined {
   return normalizeShellOutputPath(
-    runShellCommand(
+    runShellCommandOutput(
       wslHostExecutablePath,
       ["--exec", "wslpath", "-w", filePath],
-      5000,
+      shellProbeTimeoutMilliseconds,
     ),
   );
 }
@@ -436,21 +538,45 @@ function findWslExecutable(): string | undefined {
   ]);
 }
 
+interface ShellCommandResult {
+  output?: string;
+  timedOut: boolean;
+}
+
 function runShellCommand(
   shellPath: string,
   args: string[],
   timeout?: number,
-): string | undefined {
+): ShellCommandResult {
   try {
     const output = execFileSync(shellPath, args, {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
       timeout,
     }).trim();
-    return output || undefined;
-  } catch {
-    return undefined;
+    return { output: output || undefined, timedOut: false };
+  } catch (error) {
+    return { timedOut: isTimeoutError(error) };
   }
+}
+
+function runShellCommandOutput(
+  shellPath: string,
+  args: string[],
+  timeout?: number,
+): string | undefined {
+  return runShellCommand(shellPath, args, timeout).output;
+}
+
+// A probe that ran out of time is not the same answer as a probe that came
+// back empty, and callers that cache their result need to tell them apart.
+// execFileSync kills the child and rethrows on expiry; Node reports that as
+// ETIMEDOUT, or as the kill signal.
+function isTimeoutError(error: unknown): boolean {
+  const failure = error as
+    | (NodeJS.ErrnoException & { signal?: NodeJS.Signals | null })
+    | undefined;
+  return failure?.code === "ETIMEDOUT" || failure?.signal === "SIGTERM";
 }
 
 function normalizeShellOutputPath(

--- a/src/backend/executablePath.ts
+++ b/src/backend/executablePath.ts
@@ -90,6 +90,29 @@ export function createCachedCommandResolver(
   };
 }
 
+/**
+ * Resolve a command, letting a configured path win outright.
+ *
+ * Mirrors how resolveM2Executable treats macaulay2.executablePath: the path is
+ * taken as given rather than checked, so a wrong one surfaces as a start
+ * failure naming the path instead of silently falling back to auto-detection.
+ */
+export function probeConfiguredCommand(
+  configuredPath: string | undefined,
+  command: string,
+  probe: (command: string) => CommandProbe = probeCommandExecutable,
+): CommandProbe {
+  const configured = configuredPath?.trim();
+  if (configured) {
+    return {
+      resolution: { executablePath: configured, source: "setting" },
+      timedOut: false,
+    };
+  }
+
+  return probe(command);
+}
+
 export function resolveCommandExecutable(
   command: string,
 ): CommandExecutableResolution | undefined {

--- a/src/backend/executablePath.ts
+++ b/src/backend/executablePath.ts
@@ -34,6 +34,30 @@ interface ShellProbe {
   timedOut: boolean;
 }
 
+export interface ShellCommandResult {
+  output?: string;
+  timedOut: boolean;
+}
+
+interface ShellCommandExecutionOptions {
+  encoding: "utf8";
+  stdio: ["ignore", "pipe", "ignore"];
+  timeout?: number;
+  killSignal: "SIGKILL";
+}
+
+export type ShellCommandExecutor = (
+  executablePath: string,
+  args: string[],
+  options: ShellCommandExecutionOptions,
+) => string;
+
+export type ShellCommandRunner = (
+  executablePath: string,
+  args: string[],
+  timeout?: number,
+) => ShellCommandResult;
+
 export interface CachedCommandResolver {
   // Returns the probe rather than just the resolution: callers that stop
   // asking after a negative answer need to know whether it was conclusive.
@@ -56,12 +80,10 @@ const shellProbeTimeoutMilliseconds = 5000;
  * case is the one that pays it every single time -- there is no successful
  * lookup to stop the retries.
  *
- * A probe that timed out is deliberately *not* remembered.  The command may be
- * installed behind a shell that was merely slow, and caching that answer would
- * turn one unlucky probe into a session-long verdict.
- *
- * `forget` exists so an explicit user action can pick up an executable that was
- * installed after the extension activated.
+ * Timeouts are remembered too.  Retrying a synchronous probe from every editor
+ * event would replace one unlucky delay with a five-second stall on every tab
+ * switch.  `forget` is the explicit retry path, both for a timeout and for an
+ * executable installed after the extension activated.
  */
 export function createCachedCommandResolver(
   command: string,
@@ -77,10 +99,6 @@ export function createCachedCommandResolver(
       }
 
       const result = probe(command);
-      if (!result.resolution && result.timedOut) {
-        return result;
-      }
-
       cached = { probe: result };
       return result;
     },
@@ -100,8 +118,8 @@ export function resolveCommandExecutable(
  * Resolve a command, reporting whether a shell probe ran out of time.
  *
  * A timeout is not the same answer as "not installed" -- the command may well
- * be there behind a shell that was merely slow -- so callers that remember a
- * negative result need to be able to decline to remember this one.
+ * be there behind a shell that was merely slow -- so callers need to preserve
+ * that distinction even when they cache the result until an explicit retry.
  */
 export function probeCommandExecutable(command: string): CommandProbe {
   const fromPath = findCommandOnPath(command);
@@ -113,23 +131,7 @@ export function probeCommandExecutable(command: string): CommandProbe {
   }
 
   if (process.platform === "win32") {
-    const fromCygwinShell = resolveCommandWithCygwinShell(command);
-    if (fromCygwinShell.executablePath) {
-      return {
-        resolution: {
-          executablePath: fromCygwinShell.executablePath,
-          source: "Cygwin shell",
-        },
-        timedOut: false,
-      };
-    }
-
-    const fromWsl = resolveCommandWithWsl(command);
-    if (fromWsl) {
-      return { resolution: fromWsl, timedOut: false };
-    }
-
-    return { timedOut: fromCygwinShell.timedOut };
+    return probeWindowsCommandExecutable(command);
   }
 
   const fromLoginShell = resolveCommandWithLoginShell(command);
@@ -144,6 +146,30 @@ export function probeCommandExecutable(command: string): CommandProbe {
   }
 
   return { timedOut: fromLoginShell.timedOut };
+}
+
+export function probeWindowsCommandExecutable(
+  command: string,
+  probeCygwin: (command: string) => ShellProbe = resolveCommandWithCygwinShell,
+  probeWsl: (command: string) => CommandProbe = probeCommandWithWsl,
+): CommandProbe {
+  const fromCygwinShell = probeCygwin(command);
+  if (fromCygwinShell.executablePath) {
+    return {
+      resolution: {
+        executablePath: fromCygwinShell.executablePath,
+        source: "Cygwin shell",
+      },
+      timedOut: false,
+    };
+  }
+
+  const fromWsl = probeWsl(command);
+  if (fromWsl.resolution) {
+    return fromWsl;
+  }
+
+  return { timedOut: fromCygwinShell.timedOut || fromWsl.timedOut };
 }
 
 export function resolveM2Executable(
@@ -461,7 +487,7 @@ function resolveCommandWithCygwinShell(command: string): ShellProbe {
 }
 
 function resolveWithWsl(): M2ExecutableResolution | undefined {
-  const resolved = resolveCommandWithWsl("M2");
+  const resolved = probeCommandWithWsl("M2").resolution;
   if (!resolved?.args || resolved.args.length < 2) {
     return undefined;
   }
@@ -474,28 +500,33 @@ function resolveWithWsl(): M2ExecutableResolution | undefined {
   };
 }
 
-function resolveCommandWithWsl(
+export function probeCommandWithWsl(
   command: string,
-): CommandExecutableResolution | undefined {
-  const wslPath = findWslExecutable();
+  findWsl: () => string | undefined = findWslExecutable,
+  run: ShellCommandRunner = runShellCommand,
+): CommandProbe {
+  const wslPath = findWsl();
   if (!wslPath) {
-    return undefined;
+    return { timedOut: false };
   }
 
-  const resolved = runShellCommandOutput(
+  const result = run(
     wslPath,
     ["--exec", "sh", "-lc", `command -v ${quoteShellWord(command)}`],
     shellProbeTimeoutMilliseconds,
   );
-  const wslExecutablePath = normalizeShellOutputPath(resolved);
+  const wslExecutablePath = normalizeShellOutputPath(result.output);
   if (!wslExecutablePath || !isUnixAbsolutePath(wslExecutablePath)) {
-    return undefined;
+    return { timedOut: result.timedOut };
   }
 
   return {
-    executablePath: wslPath,
-    source: "WSL",
-    args: ["--exec", wslExecutablePath],
+    resolution: {
+      executablePath: wslPath,
+      source: "WSL",
+      args: ["--exec", wslExecutablePath],
+    },
+    timedOut: false,
   };
 }
 
@@ -538,21 +569,27 @@ function findWslExecutable(): string | undefined {
   ]);
 }
 
-interface ShellCommandResult {
-  output?: string;
-  timedOut: boolean;
-}
+const defaultShellCommandExecutor: ShellCommandExecutor = (
+  executablePath,
+  args,
+  options,
+) => execFileSync(executablePath, args, options);
 
-function runShellCommand(
+export function runShellCommand(
   shellPath: string,
   args: string[],
   timeout?: number,
+  execute: ShellCommandExecutor = defaultShellCommandExecutor,
 ): ShellCommandResult {
   try {
-    const output = execFileSync(shellPath, args, {
+    const output = execute(shellPath, args, {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
       timeout,
+      // execFileSync waits after a timeout until the child actually exits.
+      // SIGTERM can be trapped or ignored, so it does not impose a hard bound
+      // on this synchronous extension-host work.
+      killSignal: "SIGKILL",
     }).trim();
     return { output: output || undefined, timedOut: false };
   } catch (error) {
@@ -576,7 +613,7 @@ function isTimeoutError(error: unknown): boolean {
   const failure = error as
     | (NodeJS.ErrnoException & { signal?: NodeJS.Signals | null })
     | undefined;
-  return failure?.code === "ETIMEDOUT" || failure?.signal === "SIGTERM";
+  return failure?.code === "ETIMEDOUT" || failure?.signal === "SIGKILL";
 }
 
 function normalizeShellOutputPath(

--- a/src/backend/executableSwitcher.ts
+++ b/src/backend/executableSwitcher.ts
@@ -28,6 +28,12 @@ export function registerM2ExecutableSwitcher(
   statusBarItem.command = "macaulay2.selectExecutablePath";
   context.subscriptions.push(statusBarItem);
 
+  // This resolves the M2 executable, which is a synchronous, blocking probe:
+  // it can spawn a login shell, or Cygwin bash and wsl.exe on Windows.  It is
+  // cheap enough to leave uncached only because the triggers below are rare
+  // and user-initiated.  Wiring it to a frequent event -- with
+  // onDidChangeActiveTextEditor the tempting one -- would stall the extension
+  // host on every tab switch, which is the bug language server discovery had.
   const updateStatusBarItem = () =>
     updateM2ExecutableSwitcherStatus(statusBarItem);
 

--- a/src/backend/extension.ts
+++ b/src/backend/extension.ts
@@ -6,7 +6,8 @@ import * as vscode from "vscode";
 import * as repl from "./repl";
 import * as formatter from "./formatter";
 import client, { configureLanguageServer } from "./client";
-import { resolveCommandExecutable } from "./executablePath";
+import { createCachedCommandResolver } from "./executablePath";
+import { createLanguageServerController } from "./languageServer";
 import hljs from "highlight.js/lib/core";
 import hljsM2 from "highlightjs-macaulay2";
 
@@ -30,8 +31,6 @@ export function activate(context: vscode.ExtensionContext) {
   let completionsModule: Promise<CompletionProviderModule> | undefined;
   let completionsActivated = false;
   let activateCompletionsPromise: Promise<void> | undefined;
-  let languageServerStarted = false;
-  let languageServerStartPromise: Thenable<void> | undefined;
   const loadCompletions = () => {
     if (!completionsModule) {
       completionsModule = import("./completionProviders");
@@ -59,96 +58,44 @@ export function activate(context: vscode.ExtensionContext) {
     return completions.getWebviewCompletionItems();
   };
 
-  const isLanguageServerEnabled = () =>
-    vscode.workspace
-      .getConfiguration("macaulay2")
-      .get<boolean>("enableLanguageServer", true);
-
-  const showLanguageServerStartError = (error: unknown) => {
-    void vscode.window.showErrorMessage(
-      `Failed to start Macaulay2 Language Server: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
-  };
-
-  const configureResolvedLanguageServer = () => {
-    const resolution = resolveCommandExecutable(LANGUAGE_SERVER_COMMAND);
-    if (!resolution) {
-      return false;
-    }
-
-    configureLanguageServer(resolution.executablePath, resolution.args);
-    return true;
-  };
-
-  const startLanguageServer = () => {
-    if (languageServerStarted) {
-      return Promise.resolve();
-    }
-    if (languageServerStartPromise) {
-      return languageServerStartPromise;
-    }
-    if (!isLanguageServerEnabled() || !configureResolvedLanguageServer()) {
-      return Promise.resolve();
-    }
-
-    languageServerStartPromise = client
-      .start()
-      .then(() => {
-        languageServerStarted = true;
-      })
-      .catch((error) => {
-        showLanguageServerStartError(error);
-      })
-      .finally(() => {
-        languageServerStartPromise = undefined;
-      });
-    return languageServerStartPromise;
-  };
-
-  const restartLanguageServer = async () => {
-    if (!isLanguageServerEnabled()) {
+  const languageServer = createLanguageServerController({
+    client,
+    resolver: createCachedCommandResolver(LANGUAGE_SERVER_COMMAND),
+    configure: (resolution) =>
+      configureLanguageServer(resolution.executablePath, resolution.args),
+    isEnabled: () =>
+      vscode.workspace
+        .getConfiguration("macaulay2")
+        .get<boolean>("enableLanguageServer", true),
+    reportDisabled: () => {
       void vscode.window.showInformationMessage(
         "Macaulay2 Language Server is disabled.",
       );
-      return;
-    }
-
-    if (!configureResolvedLanguageServer()) {
+    },
+    reportNotFound: () => {
       void vscode.window.showWarningMessage(
         `${LANGUAGE_SERVER_COMMAND} was not found.`,
       );
-      return;
-    }
-
-    try {
-      if (languageServerStartPromise) {
-        await languageServerStartPromise;
-      }
-
-      if (languageServerStarted) {
-        await client.restart();
-      } else {
-        await client.start();
-        languageServerStarted = true;
-      }
-    } catch (error) {
-      languageServerStarted = false;
-      showLanguageServerStartError(error);
-    }
-  };
+    },
+    reportStartError: (error) => {
+      void vscode.window.showErrorMessage(
+        `Failed to start Macaulay2 Language Server: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    },
+  });
 
   if (vscode.workspace.textDocuments.some(isMacaulay2Document)) {
     void activateCompletions();
-    void startLanguageServer();
+    void languageServer.start();
   }
 
   context.subscriptions.push(
     vscode.workspace.onDidOpenTextDocument((document) => {
       if (isMacaulay2Document(document)) {
         void activateCompletions();
-        void startLanguageServer();
+        void languageServer.start();
       }
     }),
   );
@@ -156,7 +103,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.window.onDidChangeActiveTextEditor((editor) => {
       if (editor && isMacaulay2Document(editor.document)) {
         void activateCompletions();
-        void startLanguageServer();
+        void languageServer.start();
       }
     }),
   );
@@ -178,9 +125,8 @@ export function activate(context: vscode.ExtensionContext) {
   formatter.activate(context);
   context.subscriptions.push(client);
   context.subscriptions.push(
-    vscode.commands.registerCommand(
-      "macaulay2.restartLanguageServer",
-      restartLanguageServer,
+    vscode.commands.registerCommand("macaulay2.restartLanguageServer", () =>
+      languageServer.restart(),
     ),
   );
 

--- a/src/backend/extension.ts
+++ b/src/backend/extension.ts
@@ -5,7 +5,10 @@
 import * as vscode from "vscode";
 import * as repl from "./repl";
 import * as formatter from "./formatter";
-import { createCachedCommandResolver } from "./executablePath";
+import {
+  createCachedCommandResolver,
+  probeConfiguredCommand,
+} from "./executablePath";
 import {
   createLanguageServerController,
   LanguageServerController,
@@ -72,12 +75,24 @@ export function activate(context: vscode.ExtensionContext) {
       .getConfiguration("macaulay2")
       .get<boolean>("enableLanguageServer", true);
 
+  const getConfiguredLanguageServerPath = () =>
+    vscode.workspace
+      .getConfiguration("macaulay2")
+      .get<string>("languageServerPath", "")
+      .trim();
+
+  const languageServerResolver = createCachedCommandResolver(
+    LANGUAGE_SERVER_COMMAND,
+    (command) =>
+      probeConfiguredCommand(getConfiguredLanguageServerPath(), command),
+  );
+
   const controller = createLanguageServerController({
     // Imported lazily: this is what keeps vscode-languageclient out of
     // activation for anyone with no language server installed.
     createClient: async (resolution) =>
       (await import("./client")).createLanguageClient(resolution),
-    resolver: createCachedCommandResolver(LANGUAGE_SERVER_COMMAND),
+    resolver: languageServerResolver,
     isEnabled: isLanguageServerEnabled,
     reportDisabled: () => {
       void vscode.window.showInformationMessage(
@@ -149,6 +164,13 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((e) => {
+      // A new path means the cached resolution is stale, and restart is
+      // already the operation that re-probes and swaps the client.
+      if (e.affectsConfiguration("macaulay2.languageServerPath")) {
+        void controller.restart();
+        return;
+      }
+
       if (!e.affectsConfiguration("macaulay2.enableLanguageServer")) return;
 
       // The controller can start and stop on demand, so apply the setting

--- a/src/backend/extension.ts
+++ b/src/backend/extension.ts
@@ -5,9 +5,11 @@
 import * as vscode from "vscode";
 import * as repl from "./repl";
 import * as formatter from "./formatter";
-import client, { configureLanguageServer } from "./client";
 import { createCachedCommandResolver } from "./executablePath";
-import { createLanguageServerController } from "./languageServer";
+import {
+  createLanguageServerController,
+  LanguageServerController,
+} from "./languageServer";
 import hljs from "highlight.js/lib/core";
 import hljsM2 from "highlightjs-macaulay2";
 
@@ -16,6 +18,9 @@ hljs.registerLanguage("macaulay2", hljsM2);
 const LANGUAGE_SERVER_COMMAND = "M2-language-server";
 
 type CompletionProviderModule = typeof import("./completionProviders");
+
+// Held for deactivate(), which runs outside activate()'s scope.
+let languageServer: LanguageServerController | undefined;
 
 function isMacaulay2Document(document: vscode.TextDocument): boolean {
   return document.languageId === "macaulay2";
@@ -58,11 +63,12 @@ export function activate(context: vscode.ExtensionContext) {
     return completions.getWebviewCompletionItems();
   };
 
-  const languageServer = createLanguageServerController({
-    client,
+  const controller = createLanguageServerController({
+    // Imported lazily: this is what keeps vscode-languageclient out of
+    // activation for anyone with no language server installed.
+    createClient: async (resolution) =>
+      (await import("./client")).createLanguageClient(resolution),
     resolver: createCachedCommandResolver(LANGUAGE_SERVER_COMMAND),
-    configure: (resolution) =>
-      configureLanguageServer(resolution.executablePath, resolution.args),
     isEnabled: () =>
       vscode.workspace
         .getConfiguration("macaulay2")
@@ -86,16 +92,18 @@ export function activate(context: vscode.ExtensionContext) {
     },
   });
 
+  languageServer = controller;
+
   if (vscode.workspace.textDocuments.some(isMacaulay2Document)) {
     void activateCompletions();
-    void languageServer.start();
+    void controller.start();
   }
 
   context.subscriptions.push(
     vscode.workspace.onDidOpenTextDocument((document) => {
       if (isMacaulay2Document(document)) {
         void activateCompletions();
-        void languageServer.start();
+        void controller.start();
       }
     }),
   );
@@ -103,7 +111,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.window.onDidChangeActiveTextEditor((editor) => {
       if (editor && isMacaulay2Document(editor.document)) {
         void activateCompletions();
-        void languageServer.start();
+        void controller.start();
       }
     }),
   );
@@ -123,10 +131,10 @@ export function activate(context: vscode.ExtensionContext) {
 
   repl.activate(context, getWebviewCompletionItems);
   formatter.activate(context);
-  context.subscriptions.push(client);
+  context.subscriptions.push(controller);
   context.subscriptions.push(
     vscode.commands.registerCommand("macaulay2.restartLanguageServer", () =>
-      languageServer.restart(),
+      controller.restart(),
     ),
   );
 
@@ -168,5 +176,5 @@ export function activate(context: vscode.ExtensionContext) {
 // this method is called when your extension is deactivated
 export function deactivate(): Thenable<void> | undefined {
   repl.deactivate();
-  return client.stop();
+  return languageServer?.stop();
 }

--- a/src/backend/extension.ts
+++ b/src/backend/extension.ts
@@ -26,6 +26,10 @@ function isMacaulay2Document(document: vscode.TextDocument): boolean {
   return document.languageId === "macaulay2";
 }
 
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
@@ -63,16 +67,18 @@ export function activate(context: vscode.ExtensionContext) {
     return completions.getWebviewCompletionItems();
   };
 
+  const isLanguageServerEnabled = () =>
+    vscode.workspace
+      .getConfiguration("macaulay2")
+      .get<boolean>("enableLanguageServer", true);
+
   const controller = createLanguageServerController({
     // Imported lazily: this is what keeps vscode-languageclient out of
     // activation for anyone with no language server installed.
     createClient: async (resolution) =>
       (await import("./client")).createLanguageClient(resolution),
     resolver: createCachedCommandResolver(LANGUAGE_SERVER_COMMAND),
-    isEnabled: () =>
-      vscode.workspace
-        .getConfiguration("macaulay2")
-        .get<boolean>("enableLanguageServer", true),
+    isEnabled: isLanguageServerEnabled,
     reportDisabled: () => {
       void vscode.window.showInformationMessage(
         "Macaulay2 Language Server is disabled.",
@@ -85,9 +91,12 @@ export function activate(context: vscode.ExtensionContext) {
     },
     reportStartError: (error) => {
       void vscode.window.showErrorMessage(
-        `Failed to start Macaulay2 Language Server: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
+        `Failed to start Macaulay2 Language Server: ${describeError(error)}`,
+      );
+    },
+    reportStopError: (error) => {
+      void vscode.window.showErrorMessage(
+        `Failed to stop Macaulay2 Language Server: ${describeError(error)}`,
       );
     },
   });
@@ -140,16 +149,16 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((e) => {
-      if (e.affectsConfiguration("macaulay2.enableLanguageServer")) {
-        void vscode.window
-          .showInformationMessage(
-            "Reload the window to apply language server changes.",
-            "Reload",
-          )
-          .then((selection) => {
-            if (selection === "Reload")
-              vscode.commands.executeCommand("workbench.action.reloadWindow");
-          });
+      if (!e.affectsConfiguration("macaulay2.enableLanguageServer")) return;
+
+      // The controller can start and stop on demand, so apply the setting
+      // rather than asking for a window reload.  Turning it back on only
+      // starts the server if one is installed, which is the same thing the
+      // editor events would do.
+      if (isLanguageServerEnabled()) {
+        void controller.start();
+      } else {
+        void controller.stop();
       }
     }),
   );

--- a/src/backend/languageServer.ts
+++ b/src/backend/languageServer.ts
@@ -9,6 +9,12 @@
 // stops the editor events from asking again, and that the user command is the
 // way back from either.
 //
+// The client is created here rather than handed in, and only once a resolution
+// has actually succeeded.  That keeps vscode-languageclient out of activation
+// for anyone without a language server installed, and it means a client is
+// only ever paired with the executable it was built from: restart discards the
+// old one instead of pointing it at a new path.
+//
 
 import {
   CachedCommandResolver,
@@ -20,13 +26,14 @@ import {
 export interface LanguageServerClient {
   start(): Thenable<void>;
   stop(): Thenable<void>;
-  restart(): Thenable<void>;
+  dispose(): Thenable<void> | void;
 }
 
 export interface LanguageServerControllerOptions {
-  client: LanguageServerClient;
+  createClient(
+    resolution: CommandExecutableResolution,
+  ): Thenable<LanguageServerClient>;
   resolver: CachedCommandResolver;
-  configure(resolution: CommandExecutableResolution): void;
   isEnabled(): boolean;
   reportDisabled(): void;
   reportNotFound(): void;
@@ -38,21 +45,26 @@ export interface LanguageServerController {
   start(): Promise<void>;
   /** The "Macaulay2: Restart Language Server" command. */
   restart(): Promise<void>;
+  /** Shut the server down, for deactivate(). */
+  stop(): Promise<void>;
+  /** For context.subscriptions. */
+  dispose(): void;
 }
 
 export function createLanguageServerController(
   options: LanguageServerControllerOptions,
 ): LanguageServerController {
   const {
-    client,
+    createClient,
     resolver,
-    configure,
     isEnabled,
     reportDisabled,
     reportNotFound,
     reportStartError,
   } = options;
 
+  // Undefined until a resolution succeeds and a client is built for it.
+  let client: LanguageServerClient | undefined;
   let started = false;
   // Set once a probe has conclusively come back empty, so the editor events
   // stop asking.  Only restart() clears it, which is how a language server
@@ -83,18 +95,30 @@ export function createLanguageServerController(
     return task;
   };
 
-  // Returns whether the language server is ready to be launched, and records a
-  // conclusive "not installed" so the editor events stop asking.  A probe that
-  // merely timed out is not conclusive: the next attempt should look again.
-  const configureResolved = () => {
+  // Resolves the executable and builds a client for it, recording a conclusive
+  // "not installed" so the editor events stop asking.  A probe that merely
+  // timed out is not conclusive: the next attempt should look again.
+  const resolveClient = async () => {
     const probe = resolver.resolve();
     if (!probe.resolution) {
       missing = !probe.timedOut;
-      return false;
+      return undefined;
     }
 
-    configure(probe.resolution);
-    return true;
+    return await createClient(probe.resolution);
+  };
+
+  // Tear down whatever is running, leaving the controller as if it had never
+  // started.  Used before building a client for a new resolution, and by
+  // stop() on deactivate.
+  const discardClient = async () => {
+    const running = client;
+    client = undefined;
+    started = false;
+    if (!running) return;
+
+    await running.stop();
+    await running.dispose();
   };
 
   const start = () => {
@@ -102,9 +126,11 @@ export function createLanguageServerController(
     if (pending) return pending;
 
     return run(async () => {
-      if (!configureResolved()) return;
+      const resolved = await resolveClient();
+      if (!resolved) return;
 
-      await client.start();
+      client = resolved;
+      await resolved.start();
       started = true;
     });
   };
@@ -126,33 +152,34 @@ export function createLanguageServerController(
       resolver.forget();
       missing = false;
 
-      if (!configureResolved()) {
-        // The executable has gone since it was last resolved.  Leaving the old
-        // client running while telling the user it was not found would be a
-        // lie, and start() would then short-circuit on `started` forever.
-        if (started) {
-          await client.stop();
-          started = false;
-        }
+      // Drop the old client before resolving.  Its executable path is baked
+      // in, so it cannot be reused if the resolution has moved, and leaving it
+      // running while reporting "not found" would be a lie.
+      await discardClient();
+
+      const resolved = await resolveClient();
+      if (!resolved) {
         reportNotFound();
         return;
       }
 
-      try {
-        if (started) {
-          await client.restart();
-        } else {
-          await client.start();
-          started = true;
-        }
-      } catch (error) {
-        // A failed restart leaves the client in no state to be reused, so let
-        // a later start() try again from scratch rather than assuming it runs.
-        started = false;
-        throw error;
-      }
+      client = resolved;
+      await resolved.start();
+      started = true;
     });
   };
 
-  return { start, restart };
+  const stop = async () => {
+    if (pending) await pending;
+    await discardClient();
+  };
+
+  return {
+    start,
+    restart,
+    stop,
+    dispose() {
+      void stop();
+    },
+  };
 }

--- a/src/backend/languageServer.ts
+++ b/src/backend/languageServer.ts
@@ -36,6 +36,8 @@ export interface LanguageServerControllerOptions {
   reportNotFound(): void;
   reportStartError(error: unknown): void;
   reportStopError(error: unknown): void;
+  /** Maximum time to wait for the LSP initialize handshake. */
+  startTimeoutMilliseconds?: number;
 }
 
 export interface LanguageServerController {
@@ -56,6 +58,32 @@ type ClientResolution =
   | { state: "missing" }
   | { state: "timedOut" };
 
+interface OperationCancellation {
+  readonly cancelled: boolean;
+  readonly whenCancelled: Promise<void>;
+  cancel(): void;
+}
+
+function createOperationCancellation(): OperationCancellation {
+  let cancelled = false;
+  let resolveCancellation: () => void;
+  const whenCancelled = new Promise<void>((resolve) => {
+    resolveCancellation = resolve;
+  });
+
+  return {
+    get cancelled() {
+      return cancelled;
+    },
+    whenCancelled,
+    cancel() {
+      if (cancelled) return;
+      cancelled = true;
+      resolveCancellation();
+    },
+  };
+}
+
 export function createLanguageServerController(
   options: LanguageServerControllerOptions,
 ): LanguageServerController {
@@ -67,15 +95,22 @@ export function createLanguageServerController(
     reportNotFound,
     reportStartError,
     reportStopError,
+    startTimeoutMilliseconds = 30_000,
   } = options;
 
   let client: LanguageServerClient | undefined;
   let started = false;
+  // A configuration change should only start a server after an editor event or
+  // explicit restart has asked for one.  This keeps global settings changes
+  // from launching a server in every window activated by onStartupFinished.
+  let demanded = false;
   // A conclusive miss suppresses editor-driven starts until an explicit
   // restart or configuration change invalidates the resolution.
   let missing = false;
   let pending: Promise<void> | undefined;
+  let pendingStart: Promise<void> | undefined;
   let pendingToken = 0;
+  const cancellableOperations = new Set<OperationCancellation>();
 
   // Queue every lifecycle operation.  In particular, a start requested while
   // stop() is awaiting the language client's shutdown must run afterwards; it
@@ -100,6 +135,36 @@ export function createLanguageServerController(
     pending = task;
     return task;
   };
+
+  const trackCancellation = () => {
+    const cancellation = createOperationCancellation();
+    cancellableOperations.add(cancellation);
+    return cancellation;
+  };
+
+  const cancelCancellableOperations = () => {
+    for (const cancellation of cancellableOperations) {
+      cancellation.cancel();
+    }
+
+    // A later start must queue behind the interrupting operation rather than
+    // coalescing with the start that operation just cancelled.
+    pendingStart = undefined;
+  };
+
+  const runCancellable = (
+    cancellation: OperationCancellation,
+    work: () => Promise<void>,
+  ) =>
+    run(async () => {
+      try {
+        if (!cancellation.cancelled) await work();
+      } catch (error) {
+        if (!cancellation.cancelled) throw error;
+      } finally {
+        cancellableOperations.delete(cancellation);
+      }
+    });
 
   const resolveClient = async (): Promise<ClientResolution> => {
     const probe = resolver.resolve();
@@ -143,21 +208,102 @@ export function createLanguageServerController(
     if (failure) throw failure.error;
   };
 
-  const startClient = async (candidate: LanguageServerClient) => {
-    client = candidate;
+  const disposeUnusedClient = async (candidate: LanguageServerClient) => {
     try {
-      await candidate.start();
-      started = true;
-    } catch (error) {
+      await candidate.dispose();
+    } catch {
+      // Preserve the lifecycle result that made this candidate unused.
+    }
+  };
+
+  // Cancelling a start is different from stopping a running client.  The real
+  // vscode-languageclient rejects stop()/dispose() while it is Starting, but
+  // its node adapter still uses those calls to terminate the child process.
+  // Try both operations, suppressing the expected state error; the managed
+  // client returned by client.ts guarantees its VS Code resources are released.
+  const abandonStartingClient = async (candidate: LanguageServerClient) => {
+    if (client === candidate) client = undefined;
+    started = false;
+
+    try {
+      await candidate.stop();
+    } catch {
+      // Starting clients cannot be stopped through the base client API.
+    }
+
+    await disposeUnusedClient(candidate);
+  };
+
+  const startClient = async (
+    candidate: LanguageServerClient,
+    cancellation: OperationCancellation,
+  ) => {
+    if (cancellation.cancelled) {
+      await disposeUnusedClient(candidate);
+      return;
+    }
+
+    client = candidate;
+    const completion = (async () => {
+      try {
+        await candidate.start();
+        return { state: "started" } as const;
+      } catch (error) {
+        return { state: "failed", error } as const;
+      }
+    })();
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<{ state: "timedOut" }>((resolve) => {
+      timeoutHandle = setTimeout(
+        () => resolve({ state: "timedOut" }),
+        Math.max(0, startTimeoutMilliseconds),
+      );
+    });
+    const outcome = await Promise.race([
+      completion,
+      cancellation.whenCancelled.then(() => ({ state: "cancelled" }) as const),
+      timeout,
+    ]);
+    if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+
+    const stopLateSuccessfulStart = () => {
+      void completion.then(async (lateOutcome) => {
+        if (lateOutcome.state !== "started") return;
+        try {
+          await candidate.stop();
+        } catch {
+          // The process termination scheduled during abandonment is the
+          // fallback when a late client cannot be stopped gracefully.
+        }
+        await disposeUnusedClient(candidate);
+      });
+    };
+
+    if (outcome.state === "cancelled" || outcome.state === "timedOut") {
+      stopLateSuccessfulStart();
+      await abandonStartingClient(candidate);
+      if (outcome.state === "timedOut" && !cancellation.cancelled) {
+        throw new Error(
+          `Macaulay2 Language Server did not finish starting within ${startTimeoutMilliseconds} ms.`,
+        );
+      }
+      return;
+    }
+
+    if (outcome.state === "failed") {
       client = undefined;
       started = false;
-      try {
-        await candidate.dispose();
-      } catch {
-        // Preserve the start failure for the user; disposal is best effort.
-      }
-      throw error;
+      await disposeUnusedClient(candidate);
+      if (!cancellation.cancelled) throw outcome.error;
+      return;
     }
+
+    if (cancellation.cancelled) {
+      await abandonStartingClient(candidate);
+      return;
+    }
+
+    started = true;
   };
 
   const discardClientAndReport = async (): Promise<boolean> => {
@@ -173,13 +319,23 @@ export function createLanguageServerController(
   // Build the replacement before stopping a healthy client.  A timeout (or a
   // failure to load/build the new client) therefore leaves the running server
   // alone.  A conclusive miss still tears it down before reporting the result.
-  const replaceClient = async (announceMissing: boolean) => {
+  const replaceClient = async (
+    announceMissing: boolean,
+    cancellation: OperationCancellation,
+  ) => {
     const resolved = await resolveClient();
+    if (cancellation.cancelled) {
+      if (resolved.state === "resolved") {
+        await disposeUnusedClient(resolved.client);
+      }
+      return;
+    }
+
     if (resolved.state === "timedOut") return;
 
     if (resolved.state === "missing") {
       if (!(await discardClientAndReport())) return;
-      if (announceMissing) reportNotFound();
+      if (!cancellation.cancelled && announceMissing) reportNotFound();
       return;
     }
 
@@ -187,27 +343,48 @@ export function createLanguageServerController(
       // Resolution creates a candidate before touching the healthy client so
       // load failures preserve it.  If old-client teardown fails, the unused
       // candidate still needs to be released.
-      try {
-        await resolved.client.dispose();
-      } catch {
-        // Preserve the shutdown failure already reported above.
-      }
+      await disposeUnusedClient(resolved.client);
       return;
     }
-    await startClient(resolved.client);
+
+    if (cancellation.cancelled) {
+      await disposeUnusedClient(resolved.client);
+      return;
+    }
+    await startClient(resolved.client, cancellation);
   };
 
-  const start = () =>
-    run(async () => {
+  const start = () => {
+    demanded = true;
+    if (pendingStart) return pendingStart;
+
+    const cancellation = trackCancellation();
+    const task = runCancellable(cancellation, async () => {
       if (started || missing || !isEnabled()) return;
 
       const resolved = await resolveClient();
+      if (cancellation.cancelled) {
+        if (resolved.state === "resolved") {
+          await disposeUnusedClient(resolved.client);
+        }
+        return;
+      }
       if (resolved.state !== "resolved") return;
-      await startClient(resolved.client);
+      await startClient(resolved.client, cancellation);
     });
+    pendingStart = task;
+    const clearPendingStart = () => {
+      if (pendingStart === task) pendingStart = undefined;
+    };
+    void task.then(clearPendingStart, clearPendingStart);
+    return task;
+  };
 
-  const restart = () =>
-    run(async () => {
+  const restart = () => {
+    demanded = true;
+    cancelCancellableOperations();
+    const cancellation = trackCancellation();
+    return runCancellable(cancellation, async () => {
       if (!isEnabled()) {
         reportDisabled();
         return;
@@ -215,11 +392,14 @@ export function createLanguageServerController(
 
       resolver.forget();
       missing = false;
-      await replaceClient(true);
+      await replaceClient(true, cancellation);
     });
+  };
 
-  const configurationChanged = () =>
-    run(async () => {
+  const configurationChanged = () => {
+    cancelCancellableOperations();
+    const cancellation = trackCancellation();
+    return runCancellable(cancellation, async () => {
       // Either setting can make the cached resolution stale.  Clearing it here
       // also lets re-enabling discover a server installed while disabled.
       resolver.forget();
@@ -230,12 +410,19 @@ export function createLanguageServerController(
         return;
       }
 
+      if (!demanded) return;
+
       // Setting changes are already visible user actions, but a missing server
       // remains silent here just as it is for editor-driven start().
-      await replaceClient(false);
+      await replaceClient(false, cancellation);
     });
+  };
 
-  const stop = () => run(discardClient, reportStopError);
+  const stop = () => {
+    demanded = false;
+    cancelCancellableOperations();
+    return run(discardClient, reportStopError);
+  };
 
   return {
     start,

--- a/src/backend/languageServer.ts
+++ b/src/backend/languageServer.ts
@@ -84,17 +84,24 @@ export function createLanguageServerController(
   };
 
   // Returns whether the language server is ready to be launched, and records a
-  // conclusive "not installed" so the editor events stop asking.  A probe that
-  // merely timed out is not conclusive: the next attempt should look again.
+  // conclusive "not installed" so the editor events stop asking.  A timeout is
+  // kept distinct so restart() never tears down a healthy client because one
+  // fresh lookup was inconclusive.
   const configureResolved = () => {
     const probe = resolver.resolve();
     if (!probe.resolution) {
-      missing = !probe.timedOut;
-      return false;
+      if (probe.timedOut) {
+        missing = false;
+        return "timedOut" as const;
+      }
+
+      missing = true;
+      return "missing" as const;
     }
 
+    missing = false;
     configure(probe.resolution);
-    return true;
+    return "resolved" as const;
   };
 
   const start = () => {
@@ -102,7 +109,7 @@ export function createLanguageServerController(
     if (pending) return pending;
 
     return run(async () => {
-      if (!configureResolved()) return;
+      if (configureResolved() !== "resolved") return;
 
       await client.start();
       started = true;
@@ -126,7 +133,14 @@ export function createLanguageServerController(
       resolver.forget();
       missing = false;
 
-      if (!configureResolved()) {
+      const resolutionState = configureResolved();
+      if (resolutionState === "timedOut") {
+        // A timeout says nothing about whether the executable still exists.
+        // Keep a running client alive, and let the next explicit restart retry.
+        return;
+      }
+
+      if (resolutionState === "missing") {
         // The executable has gone since it was last resolved.  Leaving the old
         // client running while telling the user it was not found would be a
         // lie, and start() would then short-circuit on `started` forever.

--- a/src/backend/languageServer.ts
+++ b/src/backend/languageServer.ts
@@ -38,6 +38,7 @@ export interface LanguageServerControllerOptions {
   reportDisabled(): void;
   reportNotFound(): void;
   reportStartError(error: unknown): void;
+  reportStopError(error: unknown): void;
 }
 
 export interface LanguageServerController {
@@ -61,6 +62,7 @@ export function createLanguageServerController(
     reportDisabled,
     reportNotFound,
     reportStartError,
+    reportStopError,
   } = options;
 
   // Undefined until a resolution succeeds and a client is built for it.
@@ -77,13 +79,16 @@ export function createLanguageServerController(
   // operation is ever in flight and callers can await whatever is running.
   // Errors are reported once and never propagate: every caller discards the
   // result, and an unhandled rejection out of an editor event is not useful.
-  const run = (work: () => Promise<void>): Promise<void> => {
+  const run = (
+    work: () => Promise<void>,
+    report: (error: unknown) => void = reportStartError,
+  ): Promise<void> => {
     const token = ++pendingToken;
     const task = (async () => {
       try {
         await work();
       } catch (error) {
-        reportStartError(error);
+        report(error);
       } finally {
         // A restart that took the slot over while this was settling must keep
         // it, or a concurrent start would see an idle controller.
@@ -169,9 +174,15 @@ export function createLanguageServerController(
     });
   };
 
-  const stop = async () => {
-    if (pending) await pending;
-    await discardClient();
+  // Goes through run() like the others, so it queues behind an in-flight start
+  // instead of tearing the client out from under it, and so a failure to shut
+  // down is reported rather than left as an unhandled rejection.
+  const stop = () => {
+    const previous = pending;
+    return run(async () => {
+      if (previous) await previous;
+      await discardClient();
+    }, reportStopError);
   };
 
   return {

--- a/src/backend/languageServer.ts
+++ b/src/backend/languageServer.ts
@@ -1,0 +1,158 @@
+//
+// Start/restart logic for the Macaulay2 language server, kept apart from
+// activate() so it can be tested against fakes.
+//
+// The shape of the problem: start() is driven by editor events -- every opened
+// document and every switch of the active editor -- while restart() is a user
+// command, and resolving the executable is a synchronous, expensive probe.  So
+// the rules are that the probe happens at most once, that a negative answer
+// stops the editor events from asking again, and that the user command is the
+// way back from either.
+//
+
+import {
+  CachedCommandResolver,
+  CommandExecutableResolution,
+} from "./executablePath";
+
+// The slice of vscode-languageclient's LanguageClient this needs, so tests do
+// not have to construct one.
+export interface LanguageServerClient {
+  start(): Thenable<void>;
+  stop(): Thenable<void>;
+  restart(): Thenable<void>;
+}
+
+export interface LanguageServerControllerOptions {
+  client: LanguageServerClient;
+  resolver: CachedCommandResolver;
+  configure(resolution: CommandExecutableResolution): void;
+  isEnabled(): boolean;
+  reportDisabled(): void;
+  reportNotFound(): void;
+  reportStartError(error: unknown): void;
+}
+
+export interface LanguageServerController {
+  /** Idempotent and cheap to call from an editor event. */
+  start(): Promise<void>;
+  /** The "Macaulay2: Restart Language Server" command. */
+  restart(): Promise<void>;
+}
+
+export function createLanguageServerController(
+  options: LanguageServerControllerOptions,
+): LanguageServerController {
+  const {
+    client,
+    resolver,
+    configure,
+    isEnabled,
+    reportDisabled,
+    reportNotFound,
+    reportStartError,
+  } = options;
+
+  let started = false;
+  // Set once a probe has conclusively come back empty, so the editor events
+  // stop asking.  Only restart() clears it, which is how a language server
+  // installed after activation gets picked up.
+  let missing = false;
+  let pending: Promise<void> | undefined;
+  let pendingToken = 0;
+
+  // Everything that touches the client goes through here, so that at most one
+  // operation is ever in flight and callers can await whatever is running.
+  // Errors are reported once and never propagate: every caller discards the
+  // result, and an unhandled rejection out of an editor event is not useful.
+  const run = (work: () => Promise<void>): Promise<void> => {
+    const token = ++pendingToken;
+    const task = (async () => {
+      try {
+        await work();
+      } catch (error) {
+        reportStartError(error);
+      } finally {
+        // A restart that took the slot over while this was settling must keep
+        // it, or a concurrent start would see an idle controller.
+        if (pendingToken === token) pending = undefined;
+      }
+    })();
+
+    pending = task;
+    return task;
+  };
+
+  // Returns whether the language server is ready to be launched, and records a
+  // conclusive "not installed" so the editor events stop asking.  A probe that
+  // merely timed out is not conclusive: the next attempt should look again.
+  const configureResolved = () => {
+    const probe = resolver.resolve();
+    if (!probe.resolution) {
+      missing = !probe.timedOut;
+      return false;
+    }
+
+    configure(probe.resolution);
+    return true;
+  };
+
+  const start = () => {
+    if (started || missing || !isEnabled()) return Promise.resolve();
+    if (pending) return pending;
+
+    return run(async () => {
+      if (!configureResolved()) return;
+
+      await client.start();
+      started = true;
+    });
+  };
+
+  const restart = () => {
+    if (!isEnabled()) {
+      reportDisabled();
+      return Promise.resolve();
+    }
+
+    const previous = pending;
+    return run(async () => {
+      // run() never rejects, so this cannot throw.
+      if (previous) await previous;
+
+      // The one place worth paying for a fresh probe: it is how someone who
+      // has just installed the language server gets it running without
+      // reloading the window.
+      resolver.forget();
+      missing = false;
+
+      if (!configureResolved()) {
+        // The executable has gone since it was last resolved.  Leaving the old
+        // client running while telling the user it was not found would be a
+        // lie, and start() would then short-circuit on `started` forever.
+        if (started) {
+          await client.stop();
+          started = false;
+        }
+        reportNotFound();
+        return;
+      }
+
+      try {
+        if (started) {
+          await client.restart();
+        } else {
+          await client.start();
+          started = true;
+        }
+      } catch (error) {
+        // A failed restart leaves the client in no state to be reused, so let
+        // a later start() try again from scratch rather than assuming it runs.
+        started = false;
+        throw error;
+      }
+    });
+  };
+
+  return { start, restart };
+}

--- a/src/backend/test/client.test.ts
+++ b/src/backend/test/client.test.ts
@@ -1,0 +1,300 @@
+import * as assert from "assert";
+import * as path from "path";
+import type { ChildProcess } from "child_process";
+import { languages, window } from "vscode";
+import type { Disposable } from "vscode";
+import type { MessageTransports } from "vscode-languageclient/node";
+
+import {
+  CancellableLanguageClient,
+  createGuardedOutputChannel,
+  manageLanguageClient,
+} from "../client";
+import { createLanguageServerController } from "../languageServer";
+
+function deferred() {
+  let resolve: () => void;
+  const promise = new Promise<void>((done) => (resolve = done));
+  return { promise, resolve: () => resolve() };
+}
+
+async function waitForStartupStage(
+  stage: Promise<void>,
+  starting: Promise<void>,
+  reportedErrors: unknown[],
+  description: string,
+) {
+  let timer: ReturnType<typeof setTimeout>;
+  try {
+    await Promise.race([
+      stage,
+      starting.then(() => {
+        throw new Error(
+          `Startup finished before ${description}: ${reportedErrors.map(String).join("; ")}`,
+        );
+      }),
+      new Promise<void>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`Timed out waiting for ${description}`)),
+          7_000,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+// Run a real protocol peer in a child process, so closing its pipes exercises
+// vscode-languageclient's initialization, connection-close, and restart paths.
+const serverScript = `
+const rpc = require(process.argv[1]);
+const mode = process.argv[2];
+const connection = rpc.createMessageConnection(
+  new rpc.StreamMessageReader(process.stdin),
+  new rpc.StreamMessageWriter(process.stdout),
+);
+connection.onRequest("initialize", () => {
+  if (mode === "hang") return new Promise(() => {});
+  if (mode === "fail") throw new rpc.ResponseError(-32001, "Test server initialization failure");
+  return { capabilities: {} };
+});
+connection.onRequest("shutdown", () => new Promise(resolve => setTimeout(() => resolve(null), 50)));
+connection.onNotification("exit", () => process.exit());
+connection.listen();
+`;
+
+class ObservedLanguageClient extends CancellableLanguageClient {
+  readonly initializeSent = deferred();
+  readonly initializedWriting = deferred();
+  readonly releaseInitialized = deferred();
+  readonly stopRequested = deferred();
+  readonly children: ChildProcess[] = [];
+  feature: Disposable | undefined;
+
+  constructor(mode: "success" | "hang" | "fail", pauseInitialized: boolean) {
+    const outputChannel = createGuardedOutputChannel(
+      window.createOutputChannel("Macaulay2 client lifecycle test"),
+    );
+    super(
+      "macaulay2-lifecycle-test",
+      "Macaulay2 lifecycle test",
+      {
+        command: process.execPath,
+        args: [
+          "-e",
+          serverScript,
+          path.join(
+            path.dirname(require.resolve("vscode-jsonrpc/package.json")),
+            "node.js",
+          ),
+          mode,
+        ],
+        options: {
+          env: { ELECTRON_RUN_AS_NODE: "1", ELECTRON_NO_ASAR: "1" },
+        },
+      },
+      { documentSelector: [{ language: "macaulay2" }], outputChannel },
+    );
+    if (!pauseInitialized) this.releaseInitialized.resolve();
+    this.registerFeature({
+      fillClientCapabilities() {},
+      initialize: () => {
+        this.feature = languages.registerHoverProvider(
+          { language: "macaulay2" },
+          { provideHover: () => undefined },
+        );
+      },
+      clear: () => this.clearObservedFeature(),
+      getState: () => ({ kind: "static" }),
+    });
+  }
+
+  clearObservedFeature() {
+    this.feature?.dispose();
+    this.feature = undefined;
+  }
+
+  stop(timeout?: number): Promise<void> {
+    this.stopRequested.resolve();
+    return super.stop(timeout);
+  }
+
+  protected async createMessageTransports(
+    encoding: string,
+  ): Promise<MessageTransports> {
+    const transports = await super.createMessageTransports(encoding);
+    const child = (this as unknown as { _serverProcess: ChildProcess })
+      ._serverProcess;
+    assert.ok(child, "the Node language client must own the test server");
+    this.children.push(child);
+    const write = transports.writer.write.bind(transports.writer);
+    transports.writer.write = async (message) => {
+      if ("method" in message && message.method === "initialize") {
+        this.initializeSent.resolve();
+      }
+      if ("method" in message && message.method === "initialized") {
+        this.initializedWriting.resolve();
+        await this.releaseInitialized.promise;
+      }
+      return write(message);
+    };
+    return transports;
+  }
+}
+
+function createHarness(
+  mode: "success" | "hang" | "fail",
+  pauseInitialized = false,
+) {
+  const client = new ObservedLanguageClient(mode, pauseInitialized);
+  const managed = manageLanguageClient(client, client.outputChannel, 150);
+  const reportedErrors: unknown[] = [];
+  let enabled = true;
+  const controller = createLanguageServerController({
+    createClient: async () => managed,
+    resolver: {
+      resolve: () => ({
+        resolution: {
+          executablePath: process.execPath,
+          args: [],
+          source: "test fixture",
+        },
+        timedOut: false,
+      }),
+      forget() {},
+    },
+    isEnabled: () => enabled,
+    reportDisabled() {},
+    reportNotFound: () => assert.fail("the fixture server is available"),
+    reportStartError: (error) => reportedErrors.push(error),
+    reportStopError: (error) => reportedErrors.push(error),
+    startTimeoutMilliseconds: 5_000,
+  });
+  return {
+    client,
+    controller,
+    reportedErrors,
+    disable() {
+      enabled = false;
+      return controller.configurationChanged();
+    },
+    async dispose() {
+      client.releaseInitialized.resolve();
+      client.cancelStart();
+      await controller.stop();
+      await managed.dispose();
+      client.clearObservedFeature();
+      for (const child of client.children) {
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill("SIGKILL");
+        }
+      }
+    },
+  };
+}
+
+suite("Language client cancellation integration", function () {
+  this.timeout(15_000);
+
+  let notifications: string[];
+  let unhandledRejections: unknown[];
+  let originalShowErrorMessage: typeof window.showErrorMessage;
+  const recordRejection = (error: unknown) => unhandledRejections.push(error);
+
+  setup(() => {
+    notifications = [];
+    unhandledRejections = [];
+    originalShowErrorMessage = window.showErrorMessage;
+    window.showErrorMessage = ((message: string) => {
+      notifications.push(message);
+      return Promise.resolve(undefined);
+    }) as typeof window.showErrorMessage;
+    process.on("unhandledRejection", recordRejection);
+  });
+
+  teardown(() => {
+    window.showErrorMessage = originalShowErrorMessage;
+    process.removeListener("unhandledRejection", recordRejection);
+  });
+
+  test("disable during the initialized notification removes late providers and listeners", async () => {
+    const harness = createHarness("success", true);
+    try {
+      const starting = harness.controller.start();
+      await waitForStartupStage(
+        harness.client.initializedWriting.promise,
+        starting,
+        harness.reportedErrors,
+        "the initialized notification",
+      );
+      const disabling = harness.disable();
+      await harness.client.stopRequested.promise;
+      harness.client.releaseInitialized.resolve();
+      await Promise.all([starting, disabling]);
+
+      assert.strictEqual(harness.client.feature, undefined);
+      // This private library field is intentionally checked by an integration
+      // test: stop() used to clear it before initialization added a listener.
+      const listeners = (harness.client as unknown as { _listeners: unknown[] })
+        ._listeners;
+      assert.strictEqual(listeners.length, 0);
+      assert.deepStrictEqual(harness.reportedErrors, []);
+      assert.deepStrictEqual(notifications, []);
+      assert.deepStrictEqual(unhandledRejections, []);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  test("disabling a hung initialize does not notify, reject unhandled, or restart", async () => {
+    const harness = createHarness("hang");
+    try {
+      const starting = harness.controller.start();
+      await waitForStartupStage(
+        harness.client.initializeSent.promise,
+        starting,
+        harness.reportedErrors,
+        "the initialize request",
+      );
+      await Promise.all([starting, harness.disable()]);
+      // Let close events and detached promise rejections reach their handlers.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      assert.strictEqual(harness.client.children.length, 1);
+      assert.ok(
+        harness.client.children.every(
+          (child) => child.exitCode !== null || child.signalCode !== null,
+        ),
+        "cancellation must terminate the initializing child process",
+      );
+      assert.deepStrictEqual(harness.reportedErrors, []);
+      assert.deepStrictEqual(notifications, []);
+      assert.deepStrictEqual(unhandledRejections, []);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  test("an actual initialize failure still reports the server error", async () => {
+    const harness = createHarness("fail");
+    try {
+      await harness.controller.start();
+
+      assert.strictEqual(harness.reportedErrors.length, 1);
+      assert.ok(
+        String(harness.reportedErrors[0]).includes(
+          "Test server initialization failure",
+        ),
+        harness.reportedErrors.map(String).join("; "),
+      );
+      assert.ok(
+        notifications.length > 0,
+        "a real initialization error must remain visible",
+      );
+      assert.deepStrictEqual(unhandledRejections, []);
+    } finally {
+      await harness.dispose();
+    }
+  });
+});

--- a/src/backend/test/extension.test.ts
+++ b/src/backend/test/extension.test.ts
@@ -181,6 +181,20 @@ suite("Extension Tests", function () {
     );
   });
 
+  test("every contributed command is prefixed in the palette", function () {
+    // The README documents them all as "Macaulay2: ...", which is what the
+    // category produces.  Without it a command shows up bare, next to the
+    // prefixed ones.
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(__dirname, "../../package.json"), "utf8"),
+    );
+    const uncategorized = manifest.contributes.commands
+      .filter((command: { category?: string }) => !command.category)
+      .map((command: { command: string }) => command.command);
+
+    assert.deepEqual(uncategorized, []);
+  });
+
   test("matches Macaulay2 identifiers and numeric literals as editor words", function () {
     const configurationSource = fs.readFileSync(
       path.join(__dirname, "../../language-configuration.json"),

--- a/src/backend/test/extension.test.ts
+++ b/src/backend/test/extension.test.ts
@@ -448,6 +448,7 @@ suite("Language Server Controller", function () {
       reportDisabled: () => reported.push("disabled"),
       reportNotFound: () => reported.push("notFound"),
       reportStartError: () => reported.push("startError"),
+      reportStopError: () => reported.push("stopError"),
       ...overrides,
     });
 
@@ -646,6 +647,31 @@ suite("Language Server Controller", function () {
     await harness.controller.start();
     await harness.controller.stop();
 
+    assert.deepEqual(harness.clients[0].calls, ["start", "stop", "dispose"]);
+  });
+
+  test("stop then start builds a fresh client", async function () {
+    // Turning the setting off and back on goes through stop() and start()
+    // rather than a window reload, so the second start has to work.
+    const harness = createHarness([found, found]);
+
+    await harness.controller.start();
+    await harness.controller.stop();
+    await harness.controller.start();
+
+    assert.equal(harness.clients.length, 2);
+    assert.deepEqual(harness.clients[0].calls, ["start", "stop", "dispose"]);
+    assert.deepEqual(harness.clients[1].calls, ["start"]);
+  });
+
+  test("stop queues behind an in-flight start", async function () {
+    const harness = createHarness([found]);
+
+    const starting = harness.controller.start();
+    const stopping = harness.controller.stop();
+    await Promise.all([starting, stopping]);
+
+    assert.equal(harness.clients.length, 1);
     assert.deepEqual(harness.clients[0].calls, ["start", "stop", "dispose"]);
   });
 

--- a/src/backend/test/extension.test.ts
+++ b/src/backend/test/extension.test.ts
@@ -18,6 +18,7 @@ import {
 } from "../executableSwitcher";
 import {
   CachedCommandResolver,
+  CommandExecutableResolution,
   CommandProbe,
   createCachedCommandResolver,
   getM2ExecutableResolutionDetail,
@@ -375,43 +376,43 @@ suite("Executable Switcher", function () {
 });
 
 suite("Language Server Controller", function () {
+  // One entry per client the controller builds, so a test can tell "restarted
+  // the same client" from "built a second one".
   interface FakeClient {
     start(): Thenable<void>;
     stop(): Thenable<void>;
-    restart(): Thenable<void>;
+    dispose(): void;
+    executablePath: string;
     calls: string[];
-    failStart?: unknown;
-    failRestart?: unknown;
-  }
-
-  function createFakeClient(): FakeClient {
-    const client: FakeClient = {
-      calls: [],
-      start() {
-        client.calls.push("start");
-        return client.failStart
-          ? Promise.reject(client.failStart)
-          : Promise.resolve();
-      },
-      stop() {
-        client.calls.push("stop");
-        return Promise.resolve();
-      },
-      restart() {
-        client.calls.push("restart");
-        return client.failRestart
-          ? Promise.reject(client.failRestart)
-          : Promise.resolve();
-      },
-    };
-    return client;
   }
 
   function createHarness(
     probes: CommandProbe[],
     overrides: Partial<LanguageServerControllerOptions> = {},
   ) {
-    const client = createFakeClient();
+    const clients: FakeClient[] = [];
+    let failStart: unknown;
+
+    const createClient = (resolution: CommandExecutableResolution) => {
+      const client: FakeClient = {
+        executablePath: resolution.executablePath,
+        calls: [],
+        start() {
+          client.calls.push("start");
+          return failStart ? Promise.reject(failStart) : Promise.resolve();
+        },
+        stop() {
+          client.calls.push("stop");
+          return Promise.resolve();
+        },
+        dispose() {
+          client.calls.push("dispose");
+        },
+      };
+      clients.push(client);
+      return Promise.resolve(client);
+    };
+
     let probeCount = 0;
     // Runs out of scripted answers rather than repeating the last one, so a
     // controller that probes more often than expected fails loudly.
@@ -427,9 +428,8 @@ suite("Language Server Controller", function () {
 
     const reported: string[] = [];
     const controller = createLanguageServerController({
-      client,
+      createClient,
       resolver,
-      configure: () => {},
       isEnabled: () => true,
       reportDisabled: () => reported.push("disabled"),
       reportNotFound: () => reported.push("notFound"),
@@ -438,11 +438,19 @@ suite("Language Server Controller", function () {
     });
 
     return {
-      client,
+      clients,
       controller,
       reported,
+      failWith(error: unknown) {
+        failStart = error;
+      },
       get probeCount() {
         return probeCount;
+      },
+      // Flattened call log across every client built, which is what most of
+      // these tests actually care about.
+      get calls() {
+        return clients.flatMap((client) => client.calls);
       },
     };
   }
@@ -450,6 +458,13 @@ suite("Language Server Controller", function () {
   const found: CommandProbe = {
     resolution: {
       executablePath: "/usr/bin/M2-language-server",
+      source: "PATH",
+    },
+    timedOut: false,
+  };
+  const moved: CommandProbe = {
+    resolution: {
+      executablePath: "/opt/bin/M2-language-server",
       source: "PATH",
     },
     timedOut: false,
@@ -468,26 +483,37 @@ suite("Language Server Controller", function () {
     await harness.controller.start();
 
     assert.equal(harness.probeCount, 1);
-    assert.deepEqual(harness.client.calls, []);
+    assert.deepEqual(harness.clients, []);
   });
 
-  test("probes once when the language server starts", async function () {
+  test("builds no client when the language server is not installed", async function () {
+    // vscode-languageclient is imported by createClient, so never calling it
+    // is what keeps it out of activation for most users.
+    const harness = createHarness([notFound]);
+
+    await harness.controller.start();
+
+    assert.deepEqual(harness.clients, []);
+  });
+
+  test("builds no client while disabled", async function () {
+    const harness = createHarness([], { isEnabled: () => false });
+
+    await harness.controller.start();
+
+    assert.equal(harness.probeCount, 0);
+    assert.deepEqual(harness.clients, []);
+  });
+
+  test("probes once and builds one client when the server starts", async function () {
     const harness = createHarness([found]);
 
     await harness.controller.start();
     await harness.controller.start();
 
     assert.equal(harness.probeCount, 1);
-    assert.deepEqual(harness.client.calls, ["start"]);
-  });
-
-  test("does not probe while disabled", async function () {
-    const harness = createHarness([], { isEnabled: () => false });
-
-    await harness.controller.start();
-
-    assert.equal(harness.probeCount, 0);
-    assert.deepEqual(harness.client.calls, []);
+    assert.equal(harness.clients.length, 1);
+    assert.deepEqual(harness.calls, ["start"]);
   });
 
   test("coalesces concurrent starts into one", async function () {
@@ -500,7 +526,8 @@ suite("Language Server Controller", function () {
     ]);
 
     assert.equal(harness.probeCount, 1);
-    assert.deepEqual(harness.client.calls, ["start"]);
+    assert.equal(harness.clients.length, 1);
+    assert.deepEqual(harness.calls, ["start"]);
   });
 
   test("does not cache a probe that timed out", async function () {
@@ -509,34 +536,41 @@ suite("Language Server Controller", function () {
     const harness = createHarness([timedOut, found]);
 
     await harness.controller.start();
-    assert.deepEqual(harness.client.calls, []);
+    assert.deepEqual(harness.clients, []);
 
     await harness.controller.start();
 
     assert.equal(harness.probeCount, 2);
-    assert.deepEqual(harness.client.calls, ["start"]);
+    assert.deepEqual(harness.calls, ["start"]);
   });
 
   test("restart re-probes and starts a server installed since activation", async function () {
     const harness = createHarness([notFound, found]);
 
     await harness.controller.start();
-    assert.deepEqual(harness.client.calls, []);
+    assert.deepEqual(harness.clients, []);
 
     await harness.controller.restart();
 
     assert.equal(harness.probeCount, 2);
-    assert.deepEqual(harness.client.calls, ["start"]);
+    assert.deepEqual(harness.calls, ["start"]);
     assert.deepEqual(harness.reported, []);
   });
 
-  test("restart of a running server restarts the client", async function () {
-    const harness = createHarness([found, found]);
+  test("restart builds a new client rather than reusing the old one", async function () {
+    // The executable path is baked into a client at construction, so a restart
+    // that finds the server somewhere else has to build a fresh one.
+    const harness = createHarness([found, moved]);
 
     await harness.controller.start();
     await harness.controller.restart();
 
-    assert.deepEqual(harness.client.calls, ["start", "restart"]);
+    assert.deepEqual(
+      harness.clients.map((client) => client.executablePath),
+      ["/usr/bin/M2-language-server", "/opt/bin/M2-language-server"],
+    );
+    assert.deepEqual(harness.clients[0].calls, ["start", "stop", "dispose"]);
+    assert.deepEqual(harness.clients[1].calls, ["start"]);
   });
 
   test("restart reports when the language server is disabled", async function () {
@@ -556,14 +590,15 @@ suite("Language Server Controller", function () {
     await harness.controller.start();
     await harness.controller.restart();
 
-    assert.deepEqual(harness.client.calls, ["start", "stop"]);
+    assert.deepEqual(harness.clients[0].calls, ["start", "stop", "dispose"]);
     assert.deepEqual(harness.reported, ["notFound"]);
 
     await harness.controller.restart();
-    assert.deepEqual(harness.client.calls, ["start", "stop", "start"]);
+    assert.equal(harness.clients.length, 2);
+    assert.deepEqual(harness.clients[1].calls, ["start"]);
   });
 
-  test("a start racing a restart does not start the client twice", async function () {
+  test("a start racing a restart does not start a second client", async function () {
     const harness = createHarness([found, found]);
 
     await harness.controller.start();
@@ -572,36 +607,41 @@ suite("Language Server Controller", function () {
     const racing = harness.controller.start();
     await Promise.all([restarting, racing]);
 
-    assert.deepEqual(harness.client.calls, ["start", "restart"]);
+    assert.equal(harness.clients.length, 2);
+    assert.deepEqual(harness.clients[1].calls, ["start"]);
     assert.deepEqual(harness.reported, []);
   });
 
   test("reports a failed start once and allows a later retry", async function () {
     const harness = createHarness([found, found]);
-    harness.client.failStart = new Error("boom");
+    harness.failWith(new Error("boom"));
 
     await harness.controller.start();
     assert.deepEqual(harness.reported, ["startError"]);
 
-    harness.client.failStart = undefined;
+    harness.failWith(undefined);
     await harness.controller.restart();
 
-    assert.deepEqual(harness.client.calls, ["start", "start"]);
     assert.deepEqual(harness.reported, ["startError"]);
+    assert.deepEqual(harness.clients[1].calls, ["start"]);
   });
 
-  test("a failed restart leaves the server startable again", async function () {
-    const harness = createHarness([found, found, found]);
+  test("stop shuts the running client down", async function () {
+    const harness = createHarness([found]);
+
     await harness.controller.start();
+    await harness.controller.stop();
 
-    harness.client.failRestart = new Error("boom");
-    await harness.controller.restart();
-    assert.deepEqual(harness.reported, ["startError"]);
+    assert.deepEqual(harness.clients[0].calls, ["start", "stop", "dispose"]);
+  });
 
-    harness.client.failRestart = undefined;
-    await harness.controller.restart();
+  test("stop is harmless when nothing ever started", async function () {
+    const harness = createHarness([notFound]);
 
-    assert.deepEqual(harness.client.calls, ["start", "restart", "start"]);
+    await harness.controller.start();
+    await harness.controller.stop();
+
+    assert.deepEqual(harness.clients, []);
   });
 });
 

--- a/src/backend/test/extension.test.ts
+++ b/src/backend/test/extension.test.ts
@@ -24,7 +24,10 @@ import {
   getM2LaunchConfiguration,
   M2ExecutableResolution,
   normalizeM2LaunchArgs,
+  probeCommandWithWsl,
+  probeWindowsCommandExecutable,
   resolveM2Executable,
+  runShellCommand,
   windowsPathToWslPath,
   wslPathToWindowsPath,
 } from "../executablePath";
@@ -374,6 +377,51 @@ suite("Executable Switcher", function () {
   });
 });
 
+suite("Command Executable Resolution", function () {
+  test("preserves a WSL shell timeout", function () {
+    const result = probeCommandWithWsl(
+      "M2-language-server",
+      () => "C:\\Windows\\System32\\wsl.exe",
+      () => ({ timedOut: true }),
+    );
+
+    assert.deepEqual(result, { timedOut: true });
+  });
+
+  test("propagates a WSL timeout after a conclusive Cygwin miss", function () {
+    const result = probeWindowsCommandExecutable(
+      "M2-language-server",
+      () => ({ timedOut: false }),
+      () => ({ timedOut: true }),
+    );
+
+    assert.deepEqual(result, { timedOut: true });
+  });
+
+  test("uses a hard kill signal for synchronous shell probes", function () {
+    let receivedTimeout: number | undefined;
+    let receivedKillSignal: string | undefined;
+    const timeoutError = Object.assign(new Error("timed out"), {
+      signal: "SIGKILL",
+    });
+
+    const result = runShellCommand(
+      "/path/to/shell",
+      ["-lc", "command -v M2-language-server"],
+      123,
+      (_executablePath, _args, options) => {
+        receivedTimeout = options.timeout;
+        receivedKillSignal = options.killSignal;
+        throw timeoutError;
+      },
+    );
+
+    assert.equal(receivedTimeout, 123);
+    assert.equal(receivedKillSignal, "SIGKILL");
+    assert.deepEqual(result, { timedOut: true });
+  });
+});
+
 suite("Language Server Controller", function () {
   interface FakeClient {
     start(): Thenable<void>;
@@ -503,18 +551,25 @@ suite("Language Server Controller", function () {
     assert.deepEqual(harness.client.calls, ["start"]);
   });
 
-  test("does not cache a probe that timed out", async function () {
-    // A slow login shell is not evidence that the language server is absent,
-    // so the next attempt has to look again rather than inherit the verdict.
+  test("does not repeat a timed-out probe from editor starts", async function () {
+    // Editor events are not a safe retry path for synchronous discovery: a
+    // persistently slow shell would otherwise stall every tab switch.
     const harness = createHarness([timedOut, found]);
 
     await harness.controller.start();
-    assert.deepEqual(harness.client.calls, []);
-
     await harness.controller.start();
+    await harness.controller.start();
+
+    assert.equal(harness.probeCount, 1);
+    assert.deepEqual(harness.client.calls, []);
+    assert.deepEqual(harness.reported, []);
+
+    // The explicit command forgets the cached timeout and tries again.
+    await harness.controller.restart();
 
     assert.equal(harness.probeCount, 2);
     assert.deepEqual(harness.client.calls, ["start"]);
+    assert.deepEqual(harness.reported, []);
   });
 
   test("restart re-probes and starts a server installed since activation", async function () {
@@ -537,6 +592,24 @@ suite("Language Server Controller", function () {
     await harness.controller.restart();
 
     assert.deepEqual(harness.client.calls, ["start", "restart"]);
+  });
+
+  test("restart preserves a running client when resolution times out", async function () {
+    const harness = createHarness([found, timedOut, found]);
+
+    await harness.controller.start();
+    await harness.controller.restart();
+
+    assert.equal(harness.probeCount, 2);
+    assert.deepEqual(harness.client.calls, ["start"]);
+    assert.deepEqual(harness.reported, []);
+
+    // A later explicit restart retries and reuses the still-running client.
+    await harness.controller.restart();
+
+    assert.equal(harness.probeCount, 3);
+    assert.deepEqual(harness.client.calls, ["start", "restart"]);
+    assert.deepEqual(harness.reported, []);
   });
 
   test("restart reports when the language server is disabled", async function () {

--- a/src/backend/test/extension.test.ts
+++ b/src/backend/test/extension.test.ts
@@ -567,6 +567,8 @@ suite("Language Server Controller", function () {
 
     assert.equal(harness.probeCount, 1);
     assert.deepEqual(harness.clients, []);
+    // Silent: nobody asked for a language server by opening a file.
+    assert.deepEqual(harness.reported, []);
   });
 
   test("builds no client when the language server is not installed", async function () {
@@ -654,6 +656,19 @@ suite("Language Server Controller", function () {
     );
     assert.deepEqual(harness.clients[0].calls, ["start", "stop", "dispose"]);
     assert.deepEqual(harness.clients[1].calls, ["start"]);
+  });
+
+  test("restart says so when there is nothing to restart", async function () {
+    // The counterpart to start() staying silent: a restart is an explicit
+    // request, so it gets an answer every time rather than failing quietly.
+    const harness = createHarness([notFound, notFound]);
+
+    await harness.controller.restart();
+    assert.deepEqual(harness.reported, ["notFound"]);
+
+    await harness.controller.restart();
+    assert.deepEqual(harness.reported, ["notFound", "notFound"]);
+    assert.deepEqual(harness.clients, []);
   });
 
   test("restart reports when the language server is disabled", async function () {

--- a/src/backend/test/extension.test.ts
+++ b/src/backend/test/extension.test.ts
@@ -21,6 +21,7 @@ import {
   CommandExecutableResolution,
   CommandProbe,
   createCachedCommandResolver,
+  probeConfiguredCommand,
   getM2ExecutableResolutionDetail,
   getM2LaunchConfiguration,
   M2ExecutableResolution,
@@ -385,6 +386,73 @@ suite("Executable Switcher", function () {
         wslExecutablePath: "/usr/bin/M2",
       }),
       "$(terminal) M2: WSL:/usr/bin/M2",
+    );
+  });
+});
+
+suite("Configured Command Resolution", function () {
+  const autoDetected: CommandProbe = {
+    resolution: {
+      executablePath: "/usr/bin/M2-language-server",
+      source: "PATH",
+    },
+    timedOut: false,
+  };
+
+  test("a configured path wins over auto-detection", function () {
+    let probed = false;
+    const probe = probeConfiguredCommand(
+      "/opt/M2-language-server",
+      "M2-language-server",
+      () => {
+        probed = true;
+        return autoDetected;
+      },
+    );
+
+    assert.deepEqual(probe, {
+      resolution: {
+        executablePath: "/opt/M2-language-server",
+        source: "setting",
+      },
+      timedOut: false,
+    });
+    // Not just overridden afterwards: the probe must not run at all, since it
+    // is the expensive part.
+    assert.equal(probed, false);
+  });
+
+  test("an empty or whitespace setting falls back to auto-detection", function () {
+    for (const configured of [undefined, "", "   "]) {
+      assert.deepEqual(
+        probeConfiguredCommand(
+          configured,
+          "M2-language-server",
+          () => autoDetected,
+        ),
+        autoDetected,
+      );
+    }
+  });
+
+  test("a configured path is trimmed but not otherwise checked", function () {
+    // Taken as given, like macaulay2.executablePath, so a wrong path fails at
+    // startup naming itself rather than silently auto-detecting something else.
+    assert.deepEqual(
+      probeConfiguredCommand(
+        "  /nonexistent/M2-language-server  ",
+        "M2-language-server",
+        () => {
+          throw new Error("should not auto-detect");
+        },
+      ),
+      {
+        resolution: {
+          executablePath: "/nonexistent/M2-language-server",
+          source: "setting",
+        },
+        timedOut: false,
+      },
     );
   });
 });

--- a/src/backend/test/extension.test.ts
+++ b/src/backend/test/extension.test.ts
@@ -47,6 +47,7 @@ import {
   createLanguageServerController,
   LanguageServerControllerOptions,
 } from "../languageServer";
+import { createGuardedOutputChannel, manageLanguageClient } from "../client";
 
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
@@ -183,12 +184,12 @@ suite("Extension Tests", function () {
         "editor.indentSize": 4,
       },
     );
-    assert.equal(
+    const languageServerPath =
       manifest.contributes.configuration.properties[
         "macaulay2.languageServerPath"
-      ].scope,
-      "machine-overridable",
-    );
+      ];
+    assert.equal(languageServerPath.scope, "window");
+    assert.equal(languageServerPath.ignoreSync, true);
   });
 
   test("every contributed command is prefixed in the palette", function () {
@@ -560,6 +561,168 @@ suite("Command Executable Resolution", function () {
   });
 });
 
+suite("Managed Language Client", function () {
+  test("releases resources when the raw client cannot dispose", async function () {
+    let diagnosticDisposals = 0;
+    let outputDisposals = 0;
+    const output: string[] = [];
+    let rawDisposals = 0;
+    let cancellations = 0;
+    let rawDisposeTimeout: number | undefined;
+    const outputChannel = createGuardedOutputChannel({
+      name: "test",
+      append(value: string) {
+        output.push(value);
+      },
+      appendLine(value: string) {
+        output.push(`${value}\n`);
+      },
+      replace(value: string) {
+        output.splice(0, output.length, value);
+      },
+      clear() {
+        output.splice(0);
+      },
+      show() {},
+      hide() {},
+      dispose() {
+        outputDisposals += 1;
+      },
+    });
+    const managed = manageLanguageClient(
+      {
+        diagnostics: {
+          dispose() {
+            diagnosticDisposals += 1;
+          },
+        },
+        start: () => Promise.reject(new Error("start failed")),
+        stop: () => Promise.resolve(),
+        cancelStart() {
+          cancellations += 1;
+        },
+        dispose(timeout?: number) {
+          rawDisposals += 1;
+          rawDisposeTimeout = timeout;
+          return Promise.reject(new Error("raw dispose failed"));
+        },
+      },
+      outputChannel,
+      10,
+    );
+
+    outputChannel.append("before disposal");
+    await assert.rejects(async () => managed.start(), /start failed/);
+    const disposing = managed.dispose();
+    await Promise.resolve();
+    assert.equal(outputDisposals, 0);
+    await disposing;
+    await managed.dispose();
+    outputChannel.append("late callback");
+
+    assert.equal(rawDisposals, 1);
+    assert.equal(cancellations, 1);
+    assert.equal(rawDisposeTimeout, 0);
+    assert.equal(diagnosticDisposals, 1);
+    assert.equal(outputDisposals, 1);
+    assert.deepEqual(output, ["before disposal"]);
+  });
+
+  test("stops a startup that succeeds during disposal", async function () {
+    let releaseStart: () => void;
+    const startGate = new Promise<void>((resolve) => {
+      releaseStart = resolve;
+    });
+    let stopCalls = 0;
+    let outputDisposals = 0;
+    const managed = manageLanguageClient(
+      {
+        diagnostics: undefined,
+        start: () => startGate,
+        stop() {
+          stopCalls += 1;
+          assert.equal(outputDisposals, 0);
+          return Promise.resolve();
+        },
+        dispose: () => Promise.reject(new Error("still starting")),
+      },
+      {
+        dispose() {
+          outputDisposals += 1;
+        },
+      },
+      20,
+    );
+
+    const starting = managed.start();
+    const disposing = managed.dispose();
+    releaseStart();
+    await Promise.all([starting, disposing]);
+
+    assert.equal(stopCalls, 1);
+    assert.equal(outputDisposals, 1);
+  });
+
+  test("bounds disposal when startup never settles", async function () {
+    this.timeout(1000);
+
+    let outputDisposals = 0;
+    const managed = manageLanguageClient(
+      {
+        diagnostics: undefined,
+        start: () => new Promise<void>(() => {}),
+        stop: () => Promise.reject(new Error("still starting")),
+        dispose: () => Promise.reject(new Error("still starting")),
+      },
+      {
+        dispose() {
+          outputDisposals += 1;
+        },
+      },
+      10,
+    );
+
+    void managed.start();
+    await managed.dispose();
+
+    assert.equal(outputDisposals, 1);
+  });
+
+  test("waits for process termination after stop rejects", async function () {
+    this.timeout(1000);
+
+    let outputDisposals = 0;
+    let cancellations = 0;
+    const managed = manageLanguageClient(
+      {
+        diagnostics: undefined,
+        start: () => Promise.resolve(),
+        stop: () => Promise.reject(new Error("shutdown timed out")),
+        dispose: () => Promise.resolve(),
+        cancelStart() {
+          cancellations += 1;
+        },
+      },
+      {
+        dispose() {
+          outputDisposals += 1;
+        },
+      },
+      10,
+    );
+
+    await managed.start();
+    await assert.rejects(async () => managed.stop(), /shutdown timed out/);
+    const disposing = managed.dispose();
+    await Promise.resolve();
+    assert.equal(outputDisposals, 0);
+    await disposing;
+
+    assert.equal(cancellations, 1);
+    assert.equal(outputDisposals, 1);
+  });
+});
+
 suite("Language Server Controller", function () {
   // One entry per client the controller builds, so a test can tell "restarted
   // the same client" from "built a second one".
@@ -579,6 +742,7 @@ suite("Language Server Controller", function () {
     let failCreate: unknown;
     let failStart: unknown;
     let failStop: unknown;
+    let startHook: (() => Thenable<void> | void) | undefined;
     let stopHook: (() => Thenable<void> | void) | undefined;
 
     const createClient = async (resolution: CommandExecutableResolution) => {
@@ -589,6 +753,7 @@ suite("Language Server Controller", function () {
         calls: [],
         async start() {
           client.calls.push("start");
+          if (startHook) await startHook();
           if (failStart !== undefined) throw failStart;
         },
         async stop() {
@@ -607,7 +772,7 @@ suite("Language Server Controller", function () {
     let probeCount = 0;
     // Runs out of scripted answers rather than repeating the last one, so a
     // controller that probes more often than expected fails loudly.
-    const resolver: CachedCommandResolver = createCachedCommandResolver(
+    const cachedResolver = createCachedCommandResolver(
       "M2-language-server",
       () => {
         const probe = probes[probeCount];
@@ -616,6 +781,14 @@ suite("Language Server Controller", function () {
         return probe;
       },
     );
+    let forgetCount = 0;
+    const resolver: CachedCommandResolver = {
+      resolve: () => cachedResolver.resolve(),
+      forget() {
+        forgetCount += 1;
+        cachedResolver.forget();
+      },
+    };
 
     const reported: string[] = [];
     const controller = createLanguageServerController({
@@ -642,11 +815,17 @@ suite("Language Server Controller", function () {
       failStopWith(error: unknown) {
         failStop = error;
       },
+      runDuringStart(hook: (() => Thenable<void> | void) | undefined) {
+        startHook = hook;
+      },
       runDuringStop(hook: (() => Thenable<void> | void) | undefined) {
         stopHook = hook;
       },
       get probeCount() {
         return probeCount;
+      },
+      get forgetCount() {
+        return forgetCount;
       },
       // Flattened call log across every client built, which is what most of
       // these tests actually care about.
@@ -731,6 +910,22 @@ suite("Language Server Controller", function () {
     assert.equal(harness.probeCount, 1);
     assert.equal(harness.clients.length, 1);
     assert.deepEqual(harness.calls, ["start"]);
+  });
+
+  test("coalesces concurrent starts when startup rejects", async function () {
+    const harness = createHarness([found]);
+    harness.failStartWith(new Error("boom"));
+
+    await Promise.all([
+      harness.controller.start(),
+      harness.controller.start(),
+      harness.controller.start(),
+    ]);
+
+    assert.equal(harness.probeCount, 1);
+    assert.equal(harness.clients.length, 1);
+    assert.deepEqual(harness.calls, ["start", "dispose"]);
+    assert.deepEqual(harness.reported, ["startError"]);
   });
 
   test("does not repeat a timed-out probe from editor starts", async function () {
@@ -959,6 +1154,26 @@ suite("Language Server Controller", function () {
     assert.deepEqual(harness.clients[1].calls, ["start"]);
   });
 
+  test("a configuration change before first start only invalidates", async function () {
+    const harness = createHarness([moved]);
+
+    await harness.controller.configurationChanged();
+
+    assert.equal(harness.forgetCount, 1);
+    assert.equal(harness.probeCount, 0);
+    assert.deepEqual(harness.clients, []);
+
+    await harness.controller.start();
+
+    assert.equal(harness.probeCount, 1);
+    assert.equal(harness.clients.length, 1);
+    assert.equal(
+      harness.clients[0].executablePath,
+      "/opt/bin/M2-language-server",
+    );
+    assert.deepEqual(harness.clients[0].calls, ["start"]);
+  });
+
   test("configuration changes while disabled invalidate without probing", async function () {
     let enabled = true;
     const harness = createHarness([found, moved], {
@@ -1016,7 +1231,7 @@ suite("Language Server Controller", function () {
     assert.deepEqual(harness.reported, []);
   });
 
-  test("stop queues behind an in-flight start", async function () {
+  test("stop cancels a launch before the client starts", async function () {
     const harness = createHarness([found]);
 
     const starting = harness.controller.start();
@@ -1024,7 +1239,166 @@ suite("Language Server Controller", function () {
     await Promise.all([starting, stopping]);
 
     assert.equal(harness.clients.length, 1);
+    assert.deepEqual(harness.clients[0].calls, ["dispose"]);
+  });
+
+  test("stop suppresses a late client-construction failure", async function () {
+    let markConstructionEntered: () => void;
+    let releaseConstruction: () => void;
+    const constructionEntered = new Promise<void>((resolve) => {
+      markConstructionEntered = resolve;
+    });
+    const constructionGate = new Promise<void>((resolve) => {
+      releaseConstruction = resolve;
+    });
+    const harness = createHarness([found], {
+      createClient: async () => {
+        markConstructionEntered();
+        await constructionGate;
+        throw new Error("lazy import failed");
+      },
+    });
+
+    const starting = harness.controller.start();
+    await constructionEntered;
+    const stopping = harness.controller.stop();
+    releaseConstruction();
+    await Promise.all([starting, stopping]);
+
+    assert.deepEqual(harness.reported, []);
+  });
+
+  test("stop tears down a client whose start never settles", async function () {
+    this.timeout(1000);
+
+    const harness = createHarness([found]);
+    let markStartEntered: () => void;
+    const startEntered = new Promise<void>((resolve) => {
+      markStartEntered = resolve;
+    });
+    const startNeverSettles = new Promise<void>(() => {});
+    harness.runDuringStart(() => {
+      markStartEntered();
+      return startNeverSettles;
+    });
+
+    void harness.controller.start();
+    await startEntered;
+    await harness.controller.stop();
+
     assert.deepEqual(harness.clients[0].calls, ["start", "stop", "dispose"]);
+  });
+
+  test("stop tears down a cancelled client again if startup finishes late", async function () {
+    this.timeout(1000);
+
+    const harness = createHarness([found]);
+    let markStartEntered: () => void;
+    let releaseStart: () => void;
+    let markLateStop: () => void;
+    const startEntered = new Promise<void>((resolve) => {
+      markStartEntered = resolve;
+    });
+    const startGate = new Promise<void>((resolve) => {
+      releaseStart = resolve;
+    });
+    const lateStop = new Promise<void>((resolve) => {
+      markLateStop = resolve;
+    });
+    let stopCount = 0;
+    harness.runDuringStart(() => {
+      markStartEntered();
+      return startGate;
+    });
+    harness.runDuringStop(() => {
+      stopCount += 1;
+      if (stopCount === 2) markLateStop();
+    });
+
+    void harness.controller.start();
+    await startEntered;
+    await harness.controller.stop();
+    releaseStart();
+    await lateStop;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    assert.deepEqual(harness.clients[0].calls, [
+      "start",
+      "stop",
+      "dispose",
+      "stop",
+      "dispose",
+    ]);
+  });
+
+  test("a configuration change replaces a client whose start never settles", async function () {
+    this.timeout(1000);
+
+    const harness = createHarness([found, moved]);
+    let markStartEntered: () => void;
+    const startEntered = new Promise<void>((resolve) => {
+      markStartEntered = resolve;
+    });
+    harness.runDuringStart(() => {
+      harness.runDuringStart(undefined);
+      markStartEntered();
+      return new Promise<void>(() => {});
+    });
+
+    void harness.controller.start();
+    await startEntered;
+    await harness.controller.configurationChanged();
+
+    assert.deepEqual(harness.clients[0].calls, ["start", "stop", "dispose"]);
+    assert.equal(
+      harness.clients[1].executablePath,
+      moved.resolution.executablePath,
+    );
+    assert.deepEqual(harness.clients[1].calls, ["start"]);
+  });
+
+  test("times out a client whose start never settles", async function () {
+    this.timeout(1000);
+
+    const harness = createHarness([found], {
+      startTimeoutMilliseconds: 10,
+    });
+    harness.runDuringStart(() => new Promise<void>(() => {}));
+
+    await harness.controller.start();
+
+    assert.deepEqual(harness.clients[0].calls, ["start", "stop", "dispose"]);
+    assert.deepEqual(harness.reported, ["startError"]);
+  });
+
+  test("does not report a timeout superseded by stop", async function () {
+    this.timeout(1000);
+
+    const harness = createHarness([found], {
+      startTimeoutMilliseconds: 10,
+    });
+    let markStopEntered: () => void;
+    let releaseStop: () => void;
+    const stopEntered = new Promise<void>((resolve) => {
+      markStopEntered = resolve;
+    });
+    const stopGate = new Promise<void>((resolve) => {
+      releaseStop = resolve;
+    });
+    harness.runDuringStart(() => new Promise<void>(() => {}));
+    harness.runDuringStop(() => {
+      markStopEntered();
+      return stopGate;
+    });
+
+    const starting = harness.controller.start();
+    await stopEntered;
+    const stopping = harness.controller.stop();
+    releaseStop();
+    await Promise.all([starting, stopping]);
+
+    assert.deepEqual(harness.clients[0].calls, ["start", "stop", "dispose"]);
+    assert.deepEqual(harness.reported, []);
   });
 
   test("stop still disposes and reports when shutdown rejects", async function () {

--- a/src/backend/test/extension.test.ts
+++ b/src/backend/test/extension.test.ts
@@ -17,6 +17,9 @@ import {
   getM2ExecutableStatusText,
 } from "../executableSwitcher";
 import {
+  CachedCommandResolver,
+  CommandProbe,
+  createCachedCommandResolver,
   getM2ExecutableResolutionDetail,
   getM2LaunchConfiguration,
   M2ExecutableResolution,
@@ -35,6 +38,10 @@ import {
 } from "../repl";
 import { formatMacaulay2Text } from "../formatter";
 import { spacedOperators } from "../operators";
+import {
+  createLanguageServerController,
+  LanguageServerControllerOptions,
+} from "../languageServer";
 
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
@@ -364,6 +371,237 @@ suite("Executable Switcher", function () {
       }),
       "$(terminal) M2: WSL:/usr/bin/M2",
     );
+  });
+});
+
+suite("Language Server Controller", function () {
+  interface FakeClient {
+    start(): Thenable<void>;
+    stop(): Thenable<void>;
+    restart(): Thenable<void>;
+    calls: string[];
+    failStart?: unknown;
+    failRestart?: unknown;
+  }
+
+  function createFakeClient(): FakeClient {
+    const client: FakeClient = {
+      calls: [],
+      start() {
+        client.calls.push("start");
+        return client.failStart
+          ? Promise.reject(client.failStart)
+          : Promise.resolve();
+      },
+      stop() {
+        client.calls.push("stop");
+        return Promise.resolve();
+      },
+      restart() {
+        client.calls.push("restart");
+        return client.failRestart
+          ? Promise.reject(client.failRestart)
+          : Promise.resolve();
+      },
+    };
+    return client;
+  }
+
+  function createHarness(
+    probes: CommandProbe[],
+    overrides: Partial<LanguageServerControllerOptions> = {},
+  ) {
+    const client = createFakeClient();
+    let probeCount = 0;
+    // Runs out of scripted answers rather than repeating the last one, so a
+    // controller that probes more often than expected fails loudly.
+    const resolver: CachedCommandResolver = createCachedCommandResolver(
+      "M2-language-server",
+      () => {
+        const probe = probes[probeCount];
+        probeCount += 1;
+        assert.ok(probe, `unexpected probe #${probeCount}`);
+        return probe;
+      },
+    );
+
+    const reported: string[] = [];
+    const controller = createLanguageServerController({
+      client,
+      resolver,
+      configure: () => {},
+      isEnabled: () => true,
+      reportDisabled: () => reported.push("disabled"),
+      reportNotFound: () => reported.push("notFound"),
+      reportStartError: () => reported.push("startError"),
+      ...overrides,
+    });
+
+    return {
+      client,
+      controller,
+      reported,
+      get probeCount() {
+        return probeCount;
+      },
+    };
+  }
+
+  const found: CommandProbe = {
+    resolution: {
+      executablePath: "/usr/bin/M2-language-server",
+      source: "PATH",
+    },
+    timedOut: false,
+  };
+  const notFound: CommandProbe = { timedOut: false };
+  const timedOut: CommandProbe = { timedOut: true };
+
+  test("probes once when the language server is not installed", async function () {
+    // The bug this guards: start() is called from onDidChangeActiveTextEditor,
+    // so a missing language server used to mean a blocking probe per tab
+    // switch.
+    const harness = createHarness([notFound]);
+
+    await harness.controller.start();
+    await harness.controller.start();
+    await harness.controller.start();
+
+    assert.equal(harness.probeCount, 1);
+    assert.deepEqual(harness.client.calls, []);
+  });
+
+  test("probes once when the language server starts", async function () {
+    const harness = createHarness([found]);
+
+    await harness.controller.start();
+    await harness.controller.start();
+
+    assert.equal(harness.probeCount, 1);
+    assert.deepEqual(harness.client.calls, ["start"]);
+  });
+
+  test("does not probe while disabled", async function () {
+    const harness = createHarness([], { isEnabled: () => false });
+
+    await harness.controller.start();
+
+    assert.equal(harness.probeCount, 0);
+    assert.deepEqual(harness.client.calls, []);
+  });
+
+  test("coalesces concurrent starts into one", async function () {
+    const harness = createHarness([found]);
+
+    await Promise.all([
+      harness.controller.start(),
+      harness.controller.start(),
+      harness.controller.start(),
+    ]);
+
+    assert.equal(harness.probeCount, 1);
+    assert.deepEqual(harness.client.calls, ["start"]);
+  });
+
+  test("does not cache a probe that timed out", async function () {
+    // A slow login shell is not evidence that the language server is absent,
+    // so the next attempt has to look again rather than inherit the verdict.
+    const harness = createHarness([timedOut, found]);
+
+    await harness.controller.start();
+    assert.deepEqual(harness.client.calls, []);
+
+    await harness.controller.start();
+
+    assert.equal(harness.probeCount, 2);
+    assert.deepEqual(harness.client.calls, ["start"]);
+  });
+
+  test("restart re-probes and starts a server installed since activation", async function () {
+    const harness = createHarness([notFound, found]);
+
+    await harness.controller.start();
+    assert.deepEqual(harness.client.calls, []);
+
+    await harness.controller.restart();
+
+    assert.equal(harness.probeCount, 2);
+    assert.deepEqual(harness.client.calls, ["start"]);
+    assert.deepEqual(harness.reported, []);
+  });
+
+  test("restart of a running server restarts the client", async function () {
+    const harness = createHarness([found, found]);
+
+    await harness.controller.start();
+    await harness.controller.restart();
+
+    assert.deepEqual(harness.client.calls, ["start", "restart"]);
+  });
+
+  test("restart reports when the language server is disabled", async function () {
+    const harness = createHarness([], { isEnabled: () => false });
+
+    await harness.controller.restart();
+
+    assert.equal(harness.probeCount, 0);
+    assert.deepEqual(harness.reported, ["disabled"]);
+  });
+
+  test("restart stops a running server whose executable has gone", async function () {
+    // Otherwise the user is told it was not found while it is still running,
+    // and start() short-circuits on the stale started flag forever after.
+    const harness = createHarness([found, notFound, found]);
+
+    await harness.controller.start();
+    await harness.controller.restart();
+
+    assert.deepEqual(harness.client.calls, ["start", "stop"]);
+    assert.deepEqual(harness.reported, ["notFound"]);
+
+    await harness.controller.restart();
+    assert.deepEqual(harness.client.calls, ["start", "stop", "start"]);
+  });
+
+  test("a start racing a restart does not start the client twice", async function () {
+    const harness = createHarness([found, found]);
+
+    await harness.controller.start();
+
+    const restarting = harness.controller.restart();
+    const racing = harness.controller.start();
+    await Promise.all([restarting, racing]);
+
+    assert.deepEqual(harness.client.calls, ["start", "restart"]);
+    assert.deepEqual(harness.reported, []);
+  });
+
+  test("reports a failed start once and allows a later retry", async function () {
+    const harness = createHarness([found, found]);
+    harness.client.failStart = new Error("boom");
+
+    await harness.controller.start();
+    assert.deepEqual(harness.reported, ["startError"]);
+
+    harness.client.failStart = undefined;
+    await harness.controller.restart();
+
+    assert.deepEqual(harness.client.calls, ["start", "start"]);
+    assert.deepEqual(harness.reported, ["startError"]);
+  });
+
+  test("a failed restart leaves the server startable again", async function () {
+    const harness = createHarness([found, found, found]);
+    await harness.controller.start();
+
+    harness.client.failRestart = new Error("boom");
+    await harness.controller.restart();
+    assert.deepEqual(harness.reported, ["startError"]);
+
+    harness.client.failRestart = undefined;
+    await harness.controller.restart();
+
+    assert.deepEqual(harness.client.calls, ["start", "restart", "start"]);
   });
 });
 


### PR DESCRIPTION
Follow-up to the review of #29 — fixes the one issue there I'd call blocking for 1.0.0. Targets `development` so it lands ahead of the release merge.

## The bug

`startLanguageServer()` is wired to `onDidOpenTextDocument` and `onDidChangeActiveTextEditor`, and only short-circuited when the server was already started or a start was in flight. The "not installed" case memoized nothing, so every switch between `.m2` files re-ran `resolveCommandExecutable("M2-language-server")`. After the cheap `PATH` scan that blocks the extension host in `execFileSync`:

- macOS/Linux: `$SHELL -l -c 'command -v M2-language-server'`, with **no timeout** — a login shell sourcing nvm/conda/pyenv is routinely a few hundred ms, and a hanging one blocked indefinitely.
- Windows: Cygwin `bash -lc` per candidate root, then `wsl --exec` plus two more spawns for the distro name.

Since `enableLanguageServer` defaults to `true` and most people don't have `M2-language-server` installed yet, this is the common path, not an edge case.

## Changes

**Probe at most once.** `createCachedCommandResolver` caches the result including "not found". The restart command drops the cache, so someone who installs the language server mid-session gets it running without reloading the window.

**Extract the state machine.** `createLanguageServerController` (new `src/backend/languageServer.ts`) takes the client, resolver, and UI reporting as options. Inside `activate()` this logic was unreachable from a test, and the bug is a property of the state machine, so it needed to be something a test could state. Extracting it also closed two races I found on the way:

- A restart now takes over the pending slot, so a tab switch during `client.restart()` no longer calls `start()` in the window where vscode-languageclient throws `Client is currently stopping. Can only restart a full stopped client` and pops a spurious error toast.
- A restart that finds the executable gone now stops the running client, instead of reporting "not found" while leaving it up and latching `started` so `start()` short-circuits forever after.

**Bound the shell probes.** The login-shell and Cygwin probes get the 5 s timeout the WSL probes already had. Two consequences that needed care:

- A timeout is not the same answer as "not installed". Probes now report which one it was, and neither the resolver nor the controller remembers a timeout — otherwise one slow login shell becomes a session-long verdict. (Writing the test for this caught a bug in my first attempt: the resolver correctly declined to cache, but the controller's `missing` flag had already latched.)
- The Cygwin probe loops over up to a dozen bash candidates, so the timeout is a budget for the whole loop rather than per spawn.

## Known trade-off

A timeout during **M2** resolution (not just the language server) now falls through to `getUnixCandidates()`, which on macOS can select `/opt/homebrew/bin/M2` instead of the one the login shell would have found. It needs a narrow intersection — GUI-launched VS Code, M2 absent from the inherited `PATH`, a >5 s login shell, *and* a different Homebrew M2 present — and it self-heals, since M2 resolution is re-run per REPL launch rather than cached. The previous behavior wasn't better, it was an unbounded hang. Still, the fallback is silent, and the fix is to surface `timedOut` in the resolution source and the status bar. Happy to do that here or separately.

## Testing

`npm test` — 78 passing, up from 66. Twelve new tests cover the controller against a fake client: probing once when the server is missing, coalescing concurrent starts, not caching a timeout, restart picking up a newly installed server, restart stopping a vanished one, a start racing a restart, and error handling on both paths.

The last commit is a comment only: it records why M2 executable resolution is left uncached (the status bar refreshes only on activation, the select command, and config changes) so that nobody wires it to `onDidChangeActiveTextEditor` and reintroduces the same bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QruFMGMFf7esJacqKJr1ya
