### PR TITLE
Build the language client lazily, from one resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Use `F12` or run **Macaulay2: Start M2 REPL** from the Command Palette to start 
 - An integrated Macaulay2 REPL in a VS Code webview.
 - Terminal-backed evaluation in a standard VS Code terminal through a separate command/keybinding.
 - Automatic `M2` executable detection on macOS and Windows, including WSL installs on Windows, with a manual override when needed.
-- Language server support via `M2-language-server` for additional editor features when installed.
+- Language server support via `M2-language-server` for additional editor features when installed, found automatically or pointed at with a setting.
 
 ![Syntax highlighting](https://user-images.githubusercontent.com/186528/54696704-990e3480-4b2c-11e9-9376-3106aa64d618.png)
 
@@ -62,6 +62,7 @@ There is no REPL target setting. To send evaluation to the terminal from a keybi
 | `macaulay2.webviewTopLevelMode` | `webapp` | Choose the webview REPL top-level output mode: `webapp` or `standard`. |
 | `macaulay2.webviewMatrixKatexMaxEntries` | `2500` | Maximum matrix entries the webview REPL renders with KaTeX. Larger matrices use Macaulay2 net output, matching `topLevelMode = Standard`. |
 | `macaulay2.enableLanguageServer` | `true` | Enable the Macaulay2 Language Server. Requires `M2-language-server` to be installed; skipped silently if not found. |
+| `macaulay2.languageServerPath` | `""` | Absolute path to the `M2-language-server` executable. Leave empty to detect it automatically. |
 
 ## Regenerating the grammars
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ There is no REPL target setting. To send evaluation to the terminal from a keybi
 | `macaulay2.webviewTopLevelMode` | `webapp` | Choose the webview REPL top-level output mode: `webapp` or `standard`. |
 | `macaulay2.webviewMatrixKatexMaxEntries` | `2500` | Maximum matrix entries the webview REPL renders with KaTeX. Larger matrices use Macaulay2 net output, matching `topLevelMode = Standard`. |
 | `macaulay2.enableLanguageServer` | `true` | Enable the Macaulay2 Language Server. Requires `M2-language-server` to be installed; skipped silently if not found. |
-| `macaulay2.languageServerPath` | `""` | Absolute path to the `M2-language-server` executable. Leave empty to detect it automatically. On Windows, a Unix path is launched through the default WSL distribution. |
+| `macaulay2.languageServerPath` | `""` | Absolute path to the `M2-language-server` executable for the entire VS Code window. Leave empty to detect it automatically. Use User or Remote settings for machine-local paths. On Windows, a Unix path is launched through the default WSL distribution. |
 
 ## Regenerating the grammars
 

--- a/package.json
+++ b/package.json
@@ -111,6 +111,12 @@
 					"description": "Enable the Macaulay2 Language Server for enhanced language support (hover, signature help, etc.). Requires M2-language-server to be installed.",
 					"scope": "window"
 				},
+				"macaulay2.languageServerPath": {
+					"type": "string",
+					"default": "",
+					"description": "Absolute path to the M2-language-server executable. Leave empty to detect it automatically.",
+					"scope": "window"
+				},
 				"macaulay2.executablePath": {
 					"type": "string",
 					"default": "",

--- a/package.json
+++ b/package.json
@@ -26,32 +26,39 @@
 		"commands": [
 			{
 				"command": "macaulay2.startREPL",
-				"title": "Start M2 REPL"
+				"title": "Start M2 REPL",
+				"category": "Macaulay2"
 			},
 			{
 				"command": "macaulay2.startTerminal",
-				"title": "Start M2 Terminal"
+				"title": "Start M2 Terminal",
+				"category": "Macaulay2"
 			},
 			{
 				"command": "macaulay2.sendToWebview",
-				"title": "Send Line or Selection to Macaulay2 Webview"
+				"title": "Send Line or Selection to Macaulay2 Webview",
+				"category": "Macaulay2"
 			},
 			{
 				"command": "macaulay2.sendToTerminal",
-				"title": "Send Line or Selection to Macaulay2 Terminal"
+				"title": "Send Line or Selection to Macaulay2 Terminal",
+				"category": "Macaulay2"
 			},
 			{
 				"command": "macaulay2.runFile",
 				"title": "Run Macaulay2 File",
+				"category": "Macaulay2",
 				"icon": "$(play)"
 			},
 			{
 				"command": "macaulay2.interruptREPL",
-				"title": "Interrupt M2 Computation"
+				"title": "Interrupt M2 Computation",
+				"category": "Macaulay2"
 			},
 			{
 				"command": "macaulay2.selectExecutablePath",
-				"title": "Select M2 Executable"
+				"title": "Select M2 Executable",
+				"category": "Macaulay2"
 			},
 			{
 				"command": "macaulay2.restartLanguageServer",

--- a/package.json
+++ b/package.json
@@ -114,8 +114,9 @@
 				"macaulay2.languageServerPath": {
 					"type": "string",
 					"default": "",
-					"description": "Absolute path to the M2-language-server executable. Leave empty to detect it automatically. On Windows, a Unix path is launched through the default WSL distribution.",
-					"scope": "machine-overridable"
+					"description": "Absolute path to the M2-language-server executable for this VS Code window. Leave empty to detect it automatically. Use User or Remote settings for machine-local paths. On Windows, a Unix path is launched through the default WSL distribution.",
+					"scope": "window",
+					"ignoreSync": true
 				},
 				"macaulay2.executablePath": {
 					"type": "string",

--- a/src/backend/client.ts
+++ b/src/backend/client.ts
@@ -16,30 +16,331 @@ import {
   Executable,
   LanguageClient,
   LanguageClientOptions,
+  MessageTransports,
   ServerOptions,
 } from "vscode-languageclient/node";
+import { execFileSync, spawnSync } from "child_process";
+import type { ChildProcess } from "child_process";
+import { window } from "vscode";
+import type { OutputChannel, ViewColumn } from "vscode";
 
 import { CommandExecutableResolution } from "./executablePath";
+import type { LanguageServerClient } from "./languageServer";
 
-const clientOptions: LanguageClientOptions = {
-  documentSelector: [
-    { scheme: "file", language: "macaulay2" },
-    { scheme: "untitled", language: "macaulay2" },
-  ],
-};
+interface DisposableResource {
+  dispose(): unknown;
+}
+
+interface RawLanguageClient {
+  readonly diagnostics: DisposableResource | undefined;
+  start(): Thenable<void>;
+  stop(timeout?: number): Thenable<void>;
+  dispose(timeout?: number): Thenable<void>;
+  cancelStart?(): void;
+}
+
+const PROCESS_TERMINATION_GRACE_MILLISECONDS = 2_500;
+
+function terminatePosixProcessTree(pid: number, visited = new Set<number>()) {
+  if (visited.has(pid)) return;
+  visited.add(pid);
+
+  try {
+    const descendants = spawnSync("pgrep", ["-P", pid.toString()], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 1_000,
+    });
+    if (typeof descendants.stdout === "string") {
+      for (const line of descendants.stdout.split(/\s+/)) {
+        if (!/^\d+$/.test(line)) continue;
+        terminatePosixProcessTree(Number(line), visited);
+      }
+    }
+  } catch {
+    // Killing the known process is still better than abandoning cleanup when
+    // process enumeration is unavailable.
+  }
+
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    // A process can exit while its tree is being enumerated.
+  }
+}
+
+function terminateChildProcess(child: ChildProcess) {
+  if (
+    child.pid === undefined ||
+    child.exitCode !== null ||
+    child.signalCode !== null
+  ) {
+    return;
+  }
+
+  try {
+    if (process.platform === "win32") {
+      execFileSync("taskkill", ["/T", "/F", "/PID", child.pid.toString()], {
+        stdio: "ignore",
+        timeout: 2_000,
+      });
+    } else if (process.platform === "darwin" || process.platform === "linux") {
+      terminatePosixProcessTree(child.pid);
+    } else {
+      child.kill("SIGKILL");
+    }
+  } catch {
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // The process may already have exited between the checks above.
+    }
+  }
+}
+
+class CancellableLanguageClient extends LanguageClient {
+  private cancellationRequested = false;
+  private ownedServerProcess: ChildProcess | undefined;
+
+  cancelStart() {
+    this.cancellationRequested = true;
+    this.captureServerProcess();
+    this.terminateServerProcess();
+  }
+
+  protected async createMessageTransports(
+    encoding: string,
+  ): Promise<MessageTransports> {
+    try {
+      const transports = await super.createMessageTransports(encoding);
+      this.captureServerProcess();
+      if (this.cancellationRequested) {
+        this.terminateServerProcess();
+        throw new Error("Language server start was cancelled.");
+      }
+      return transports;
+    } catch (error) {
+      this.captureServerProcess();
+      if (this.cancellationRequested) this.terminateServerProcess();
+      throw error;
+    }
+  }
+
+  private captureServerProcess() {
+    const spawned = (this as unknown as { _serverProcess?: ChildProcess })
+      ._serverProcess;
+    if (!spawned || this.ownedServerProcess === spawned) return;
+
+    this.ownedServerProcess = spawned;
+    spawned.once("exit", () => {
+      if (this.ownedServerProcess === spawned) {
+        this.ownedServerProcess = undefined;
+      }
+    });
+  }
+
+  private terminateServerProcess() {
+    if (this.ownedServerProcess) {
+      terminateChildProcess(this.ownedServerProcess);
+    }
+  }
+}
+
+class GuardedOutputChannel implements OutputChannel {
+  readonly name: string;
+  private closed = false;
+
+  constructor(private readonly channel: OutputChannel) {
+    this.name = channel.name;
+  }
+
+  append(value: string) {
+    if (!this.closed) this.channel.append(value);
+  }
+
+  appendLine(value: string) {
+    if (!this.closed) this.channel.appendLine(value);
+  }
+
+  replace(value: string) {
+    if (!this.closed) this.channel.replace(value);
+  }
+
+  clear() {
+    if (!this.closed) this.channel.clear();
+  }
+
+  show(preserveFocus?: boolean): void;
+  show(column?: ViewColumn, preserveFocus?: boolean): void;
+  show(columnOrPreserveFocus?: ViewColumn | boolean, preserveFocus?: boolean) {
+    if (this.closed) return;
+    if (typeof columnOrPreserveFocus === "number") {
+      this.channel.show(columnOrPreserveFocus, preserveFocus);
+    } else {
+      this.channel.show(columnOrPreserveFocus);
+    }
+  }
+
+  hide() {
+    if (!this.closed) this.channel.hide();
+  }
+
+  dispose() {
+    if (this.closed) return;
+    this.closed = true;
+    this.channel.dispose();
+  }
+}
+
+export function createGuardedOutputChannel(
+  channel: OutputChannel,
+): OutputChannel {
+  return new GuardedOutputChannel(channel);
+}
+
+function disposeQuietly(resource: DisposableResource | undefined) {
+  try {
+    resource?.dispose();
+  } catch {
+    // Cleanup is best effort, and must not hide the lifecycle error that led
+    // here.
+  }
+}
+
+// vscode-languageclient 9 rejects dispose() while a client is Starting or
+// StartFailed, before releasing the diagnostic collection and output channel.
+// Own those resources outside the client so every failed or cancelled start
+// has an idempotent cleanup path.
+export function manageLanguageClient(
+  client: RawLanguageClient,
+  outputChannel: DisposableResource,
+  processTerminationGraceMilliseconds = PROCESS_TERMINATION_GRACE_MILLISECONDS,
+): LanguageServerClient {
+  let disposal: Promise<void> | undefined;
+  let disposalRequested = false;
+  let startPending = false;
+  let startCleanup: Promise<void> | undefined;
+  let stopFailed = false;
+
+  return {
+    start() {
+      startPending = true;
+      try {
+        const result = client.start();
+        startCleanup = Promise.resolve(result)
+          .then(
+            async () => {
+              if (!disposalRequested) return;
+              try {
+                await client.stop();
+              } catch {
+                // dispose(0) already scheduled forced process termination.
+              }
+            },
+            () => {
+              // The controller reports the original start failure.
+            },
+          )
+          .finally(() => {
+            startPending = false;
+          });
+        return result;
+      } catch (error) {
+        startPending = false;
+        throw error;
+      }
+    },
+    async stop() {
+      try {
+        await client.stop();
+      } catch (error) {
+        stopFailed = true;
+        throw error;
+      }
+    },
+    dispose() {
+      disposalRequested = true;
+      if (!disposal) {
+        client.cancelStart?.();
+        const diagnostics = client.diagnostics;
+        const pendingStart = startPending ? startCleanup : undefined;
+        disposal = (async () => {
+          let rawDisposeFailed = false;
+          try {
+            // Zero makes the library's own shutdown race return immediately.
+            // Its Node adapter still schedules termination of a child process
+            // that was created by an incomplete start.
+            await client.dispose(0);
+          } catch {
+            // StartFailed and Starting are expected to reject here.
+            rawDisposeFailed = true;
+          }
+
+          if (rawDisposeFailed || stopFailed || pendingStart) {
+            // The Node client schedules forced child termination two seconds
+            // after stop() rejects in Starting state.  Wait for a late start
+            // to be stopped, or just beyond that bounded termination window,
+            // before a replacement can launch.
+            let graceHandle: ReturnType<typeof setTimeout> | undefined;
+            const grace = new Promise<void>((resolve) => {
+              graceHandle = setTimeout(
+                resolve,
+                Math.max(0, processTerminationGraceMilliseconds),
+              );
+            });
+            if (rawDisposeFailed || stopFailed) {
+              // StartFailed settles its start promise before dispose() gets
+              // here, but its child termination is still only scheduled.  Do
+              // not let that rejection shorten the process grace period.
+              await grace;
+            } else if (pendingStart) {
+              await Promise.race([pendingStart, grace]);
+            }
+            if (graceHandle !== undefined) clearTimeout(graceHandle);
+          }
+
+          // A normal stop clears diagnostics itself.  A failed start leaves
+          // the same collection installed, so release it explicitly.
+          if (client.diagnostics === diagnostics) {
+            disposeQuietly(diagnostics);
+          }
+          disposeQuietly(outputChannel);
+        })();
+      }
+
+      return disposal;
+    },
+  };
+}
 
 export function createLanguageClient(
   resolution: CommandExecutableResolution,
-): LanguageClient {
+): LanguageServerClient {
   const serverOptions: Executable = {
     command: resolution.executablePath,
     args: resolution.args,
   };
-
-  return new LanguageClient(
-    "macaulay2-language-server",
-    "Macaulay2 Language Server",
-    serverOptions as ServerOptions,
-    clientOptions,
+  const outputChannel = createGuardedOutputChannel(
+    window.createOutputChannel("Macaulay2 Language Server"),
   );
+  const clientOptions: LanguageClientOptions = {
+    documentSelector: [
+      { scheme: "file", language: "macaulay2" },
+      { scheme: "untitled", language: "macaulay2" },
+    ],
+    outputChannel,
+  };
+
+  try {
+    const client = new CancellableLanguageClient(
+      "macaulay2-language-server",
+      "Macaulay2 Language Server",
+      serverOptions as ServerOptions,
+      clientOptions,
+    );
+    return manageLanguageClient(client, outputChannel);
+  } catch (error) {
+    disposeQuietly(outputChannel);
+    throw error;
+  }
 }

--- a/src/backend/client.ts
+++ b/src/backend/client.ts
@@ -1,3 +1,17 @@
+//
+// Construction of the Macaulay2 language client.
+//
+// This module is loaded through a dynamic import, so that the extension does
+// not pull vscode-languageclient into activation for the many users who have
+// no M2-language-server installed, or who have turned the setting off.
+//
+// Each client is built from one resolution and never mutated afterwards.  The
+// server options are read when the client starts, so mutating them in place
+// happens to work, but it leaves the client's configuration and the executable
+// it was resolved from able to drift apart.  Building a fresh client when the
+// resolution changes keeps them the same thing.
+//
+
 import {
   Executable,
   LanguageClient,
@@ -5,9 +19,7 @@ import {
   ServerOptions,
 } from "vscode-languageclient/node";
 
-const serverOptions: Executable = {
-  command: "M2-language-server",
-};
+import { CommandExecutableResolution } from "./executablePath";
 
 const clientOptions: LanguageClientOptions = {
   documentSelector: [
@@ -16,14 +28,18 @@ const clientOptions: LanguageClientOptions = {
   ],
 };
 
-export function configureLanguageServer(command: string, args?: string[]) {
-  serverOptions.command = command;
-  serverOptions.args = args;
-}
+export function createLanguageClient(
+  resolution: CommandExecutableResolution,
+): LanguageClient {
+  const serverOptions: Executable = {
+    command: resolution.executablePath,
+    args: resolution.args,
+  };
 
-export default new LanguageClient(
-  "macaulay2-language-server",
-  "Macaulay2 Language Server",
-  serverOptions as ServerOptions,
-  clientOptions,
-);
+  return new LanguageClient(
+    "macaulay2-language-server",
+    "Macaulay2 Language Server",
+    serverOptions as ServerOptions,
+    clientOptions,
+  );
+}

--- a/src/backend/executablePath.ts
+++ b/src/backend/executablePath.ts
@@ -90,6 +90,29 @@ export function createCachedCommandResolver(
   };
 }
 
+/**
+ * Resolve a command, letting a configured path win outright.
+ *
+ * Mirrors how resolveM2Executable treats macaulay2.executablePath: the path is
+ * taken as given rather than checked, so a wrong one surfaces as a start
+ * failure naming the path instead of silently falling back to auto-detection.
+ */
+export function probeConfiguredCommand(
+  configuredPath: string | undefined,
+  command: string,
+  probe: (command: string) => CommandProbe = probeCommandExecutable,
+): CommandProbe {
+  const configured = configuredPath?.trim();
+  if (configured) {
+    return {
+      resolution: { executablePath: configured, source: "setting" },
+      timedOut: false,
+    };
+  }
+
+  return probe(command);
+}
+
 export function resolveCommandExecutable(
   command: string,
 ): CommandExecutableResolution | undefined {

--- a/src/backend/extension.ts
+++ b/src/backend/extension.ts
@@ -5,7 +5,10 @@
 import * as vscode from "vscode";
 import * as repl from "./repl";
 import * as formatter from "./formatter";
-import { createCachedCommandResolver } from "./executablePath";
+import {
+  createCachedCommandResolver,
+  probeConfiguredCommand,
+} from "./executablePath";
 import {
   createLanguageServerController,
   LanguageServerController,
@@ -72,12 +75,24 @@ export function activate(context: vscode.ExtensionContext) {
       .getConfiguration("macaulay2")
       .get<boolean>("enableLanguageServer", true);
 
+  const getConfiguredLanguageServerPath = () =>
+    vscode.workspace
+      .getConfiguration("macaulay2")
+      .get<string>("languageServerPath", "")
+      .trim();
+
+  const languageServerResolver = createCachedCommandResolver(
+    LANGUAGE_SERVER_COMMAND,
+    (command) =>
+      probeConfiguredCommand(getConfiguredLanguageServerPath(), command),
+  );
+
   const controller = createLanguageServerController({
     // Imported lazily: this is what keeps vscode-languageclient out of
     // activation for anyone with no language server installed.
     createClient: async (resolution) =>
       (await import("./client")).createLanguageClient(resolution),
-    resolver: createCachedCommandResolver(LANGUAGE_SERVER_COMMAND),
+    resolver: languageServerResolver,
     isEnabled: isLanguageServerEnabled,
     reportDisabled: () => {
       void vscode.window.showInformationMessage(
@@ -149,6 +164,13 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((e) => {
+      // A new path means the cached resolution is stale, and restart is
+      // already the operation that re-probes and swaps the client.
+      if (e.affectsConfiguration("macaulay2.languageServerPath")) {
+        void controller.restart();
+        return;
+      }
+
       if (!e.affectsConfiguration("macaulay2.enableLanguageServer")) return;
 
       // The controller can start and stop on demand, so apply the setting

--- a/src/backend/extension.ts
+++ b/src/backend/extension.ts
@@ -5,9 +5,11 @@
 import * as vscode from "vscode";
 import * as repl from "./repl";
 import * as formatter from "./formatter";
-import client, { configureLanguageServer } from "./client";
 import { createCachedCommandResolver } from "./executablePath";
-import { createLanguageServerController } from "./languageServer";
+import {
+  createLanguageServerController,
+  LanguageServerController,
+} from "./languageServer";
 import hljs from "highlight.js/lib/core";
 import hljsM2 from "highlightjs-macaulay2";
 
@@ -16,6 +18,9 @@ hljs.registerLanguage("macaulay2", hljsM2);
 const LANGUAGE_SERVER_COMMAND = "M2-language-server";
 
 type CompletionProviderModule = typeof import("./completionProviders");
+
+// Held for deactivate(), which runs outside activate()'s scope.
+let languageServer: LanguageServerController | undefined;
 
 function isMacaulay2Document(document: vscode.TextDocument): boolean {
   return document.languageId === "macaulay2";
@@ -58,11 +63,12 @@ export function activate(context: vscode.ExtensionContext) {
     return completions.getWebviewCompletionItems();
   };
 
-  const languageServer = createLanguageServerController({
-    client,
+  const controller = createLanguageServerController({
+    // Imported lazily: this is what keeps vscode-languageclient out of
+    // activation for anyone with no language server installed.
+    createClient: async (resolution) =>
+      (await import("./client")).createLanguageClient(resolution),
     resolver: createCachedCommandResolver(LANGUAGE_SERVER_COMMAND),
-    configure: (resolution) =>
-      configureLanguageServer(resolution.executablePath, resolution.args),
     isEnabled: () =>
       vscode.workspace
         .getConfiguration("macaulay2")
@@ -86,16 +92,18 @@ export function activate(context: vscode.ExtensionContext) {
     },
   });
 
+  languageServer = controller;
+
   if (vscode.workspace.textDocuments.some(isMacaulay2Document)) {
     void activateCompletions();
-    void languageServer.start();
+    void controller.start();
   }
 
   context.subscriptions.push(
     vscode.workspace.onDidOpenTextDocument((document) => {
       if (isMacaulay2Document(document)) {
         void activateCompletions();
-        void languageServer.start();
+        void controller.start();
       }
     }),
   );
@@ -103,7 +111,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.window.onDidChangeActiveTextEditor((editor) => {
       if (editor && isMacaulay2Document(editor.document)) {
         void activateCompletions();
-        void languageServer.start();
+        void controller.start();
       }
     }),
   );
@@ -123,10 +131,10 @@ export function activate(context: vscode.ExtensionContext) {
 
   repl.activate(context, getWebviewCompletionItems);
   formatter.activate(context);
-  context.subscriptions.push(client);
+  context.subscriptions.push(controller);
   context.subscriptions.push(
     vscode.commands.registerCommand("macaulay2.restartLanguageServer", () =>
-      languageServer.restart(),
+      controller.restart(),
     ),
   );
 
@@ -168,5 +176,5 @@ export function activate(context: vscode.ExtensionContext) {
 // this method is called when your extension is deactivated
 export function deactivate(): Thenable<void> | undefined {
   repl.deactivate();
-  return client.stop();
+  return languageServer?.stop();
 }

--- a/src/backend/extension.ts
+++ b/src/backend/extension.ts
@@ -26,6 +26,10 @@ function isMacaulay2Document(document: vscode.TextDocument): boolean {
   return document.languageId === "macaulay2";
 }
 
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
@@ -63,16 +67,18 @@ export function activate(context: vscode.ExtensionContext) {
     return completions.getWebviewCompletionItems();
   };
 
+  const isLanguageServerEnabled = () =>
+    vscode.workspace
+      .getConfiguration("macaulay2")
+      .get<boolean>("enableLanguageServer", true);
+
   const controller = createLanguageServerController({
     // Imported lazily: this is what keeps vscode-languageclient out of
     // activation for anyone with no language server installed.
     createClient: async (resolution) =>
       (await import("./client")).createLanguageClient(resolution),
     resolver: createCachedCommandResolver(LANGUAGE_SERVER_COMMAND),
-    isEnabled: () =>
-      vscode.workspace
-        .getConfiguration("macaulay2")
-        .get<boolean>("enableLanguageServer", true),
+    isEnabled: isLanguageServerEnabled,
     reportDisabled: () => {
       void vscode.window.showInformationMessage(
         "Macaulay2 Language Server is disabled.",
@@ -85,9 +91,12 @@ export function activate(context: vscode.ExtensionContext) {
     },
     reportStartError: (error) => {
       void vscode.window.showErrorMessage(
-        `Failed to start Macaulay2 Language Server: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
+        `Failed to start Macaulay2 Language Server: ${describeError(error)}`,
+      );
+    },
+    reportStopError: (error) => {
+      void vscode.window.showErrorMessage(
+        `Failed to stop Macaulay2 Language Server: ${describeError(error)}`,
       );
     },
   });
@@ -140,16 +149,16 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((e) => {
-      if (e.affectsConfiguration("macaulay2.enableLanguageServer")) {
-        void vscode.window
-          .showInformationMessage(
-            "Reload the window to apply language server changes.",
-            "Reload",
-          )
-          .then((selection) => {
-            if (selection === "Reload")
-              vscode.commands.executeCommand("workbench.action.reloadWindow");
-          });
+      if (!e.affectsConfiguration("macaulay2.enableLanguageServer")) return;
+
+      // The controller can start and stop on demand, so apply the setting
+      // rather than asking for a window reload.  Turning it back on only
+      // starts the server if one is installed, which is the same thing the
+      // editor events would do.
+      if (isLanguageServerEnabled()) {
+        void controller.start();
+      } else {
+        void controller.stop();
       }
     }),
   );

--- a/src/backend/languageServer.ts
+++ b/src/backend/languageServer.ts
@@ -9,6 +9,12 @@
 // stops the editor events from asking again, and that the user command is the
 // way back from either.
 //
+// The client is created here rather than handed in, and only once a resolution
+// has actually succeeded.  That keeps vscode-languageclient out of activation
+// for anyone without a language server installed, and it means a client is
+// only ever paired with the executable it was built from: restart discards the
+// old one instead of pointing it at a new path.
+//
 
 import {
   CachedCommandResolver,
@@ -20,13 +26,14 @@ import {
 export interface LanguageServerClient {
   start(): Thenable<void>;
   stop(): Thenable<void>;
-  restart(): Thenable<void>;
+  dispose(): Thenable<void> | void;
 }
 
 export interface LanguageServerControllerOptions {
-  client: LanguageServerClient;
+  createClient(
+    resolution: CommandExecutableResolution,
+  ): Thenable<LanguageServerClient>;
   resolver: CachedCommandResolver;
-  configure(resolution: CommandExecutableResolution): void;
   isEnabled(): boolean;
   reportDisabled(): void;
   reportNotFound(): void;
@@ -38,21 +45,26 @@ export interface LanguageServerController {
   start(): Promise<void>;
   /** The "Macaulay2: Restart Language Server" command. */
   restart(): Promise<void>;
+  /** Shut the server down, for deactivate(). */
+  stop(): Promise<void>;
+  /** For context.subscriptions. */
+  dispose(): void;
 }
 
 export function createLanguageServerController(
   options: LanguageServerControllerOptions,
 ): LanguageServerController {
   const {
-    client,
+    createClient,
     resolver,
-    configure,
     isEnabled,
     reportDisabled,
     reportNotFound,
     reportStartError,
   } = options;
 
+  // Undefined until a resolution succeeds and a client is built for it.
+  let client: LanguageServerClient | undefined;
   let started = false;
   // Set once a probe has conclusively come back empty, so the editor events
   // stop asking.  Only restart() clears it, which is how a language server
@@ -83,18 +95,30 @@ export function createLanguageServerController(
     return task;
   };
 
-  // Returns whether the language server is ready to be launched, and records a
-  // conclusive "not installed" so the editor events stop asking.  A probe that
-  // merely timed out is not conclusive: the next attempt should look again.
-  const configureResolved = () => {
+  // Resolves the executable and builds a client for it, recording a conclusive
+  // "not installed" so the editor events stop asking.  A probe that merely
+  // timed out is not conclusive: the next attempt should look again.
+  const resolveClient = async () => {
     const probe = resolver.resolve();
     if (!probe.resolution) {
       missing = !probe.timedOut;
-      return false;
+      return undefined;
     }
 
-    configure(probe.resolution);
-    return true;
+    return await createClient(probe.resolution);
+  };
+
+  // Tear down whatever is running, leaving the controller as if it had never
+  // started.  Used before building a client for a new resolution, and by
+  // stop() on deactivate.
+  const discardClient = async () => {
+    const running = client;
+    client = undefined;
+    started = false;
+    if (!running) return;
+
+    await running.stop();
+    await running.dispose();
   };
 
   const start = () => {
@@ -102,9 +126,11 @@ export function createLanguageServerController(
     if (pending) return pending;
 
     return run(async () => {
-      if (!configureResolved()) return;
+      const resolved = await resolveClient();
+      if (!resolved) return;
 
-      await client.start();
+      client = resolved;
+      await resolved.start();
       started = true;
     });
   };
@@ -126,33 +152,34 @@ export function createLanguageServerController(
       resolver.forget();
       missing = false;
 
-      if (!configureResolved()) {
-        // The executable has gone since it was last resolved.  Leaving the old
-        // client running while telling the user it was not found would be a
-        // lie, and start() would then short-circuit on `started` forever.
-        if (started) {
-          await client.stop();
-          started = false;
-        }
+      // Drop the old client before resolving.  Its executable path is baked
+      // in, so it cannot be reused if the resolution has moved, and leaving it
+      // running while reporting "not found" would be a lie.
+      await discardClient();
+
+      const resolved = await resolveClient();
+      if (!resolved) {
         reportNotFound();
         return;
       }
 
-      try {
-        if (started) {
-          await client.restart();
-        } else {
-          await client.start();
-          started = true;
-        }
-      } catch (error) {
-        // A failed restart leaves the client in no state to be reused, so let
-        // a later start() try again from scratch rather than assuming it runs.
-        started = false;
-        throw error;
-      }
+      client = resolved;
+      await resolved.start();
+      started = true;
     });
   };
 
-  return { start, restart };
+  const stop = async () => {
+    if (pending) await pending;
+    await discardClient();
+  };
+
+  return {
+    start,
+    restart,
+    stop,
+    dispose() {
+      void stop();
+    },
+  };
 }

--- a/src/backend/languageServer.ts
+++ b/src/backend/languageServer.ts
@@ -36,6 +36,8 @@ export interface LanguageServerControllerOptions {
   reportNotFound(): void;
   reportStartError(error: unknown): void;
   reportStopError(error: unknown): void;
+  /** Maximum time to wait for the LSP initialize handshake. */
+  startTimeoutMilliseconds?: number;
 }
 
 export interface LanguageServerController {
@@ -56,6 +58,32 @@ type ClientResolution =
   | { state: "missing" }
   | { state: "timedOut" };
 
+interface OperationCancellation {
+  readonly cancelled: boolean;
+  readonly whenCancelled: Promise<void>;
+  cancel(): void;
+}
+
+function createOperationCancellation(): OperationCancellation {
+  let cancelled = false;
+  let resolveCancellation: () => void;
+  const whenCancelled = new Promise<void>((resolve) => {
+    resolveCancellation = resolve;
+  });
+
+  return {
+    get cancelled() {
+      return cancelled;
+    },
+    whenCancelled,
+    cancel() {
+      if (cancelled) return;
+      cancelled = true;
+      resolveCancellation();
+    },
+  };
+}
+
 export function createLanguageServerController(
   options: LanguageServerControllerOptions,
 ): LanguageServerController {
@@ -67,15 +95,22 @@ export function createLanguageServerController(
     reportNotFound,
     reportStartError,
     reportStopError,
+    startTimeoutMilliseconds = 30_000,
   } = options;
 
   let client: LanguageServerClient | undefined;
   let started = false;
+  // A configuration change should only start a server after an editor event or
+  // explicit restart has asked for one.  This keeps global settings changes
+  // from launching a server in every window activated by onStartupFinished.
+  let demanded = false;
   // A conclusive miss suppresses editor-driven starts until an explicit
   // restart or configuration change invalidates the resolution.
   let missing = false;
   let pending: Promise<void> | undefined;
+  let pendingStart: Promise<void> | undefined;
   let pendingToken = 0;
+  const cancellableOperations = new Set<OperationCancellation>();
 
   // Queue every lifecycle operation.  In particular, a start requested while
   // stop() is awaiting the language client's shutdown must run afterwards; it
@@ -100,6 +135,36 @@ export function createLanguageServerController(
     pending = task;
     return task;
   };
+
+  const trackCancellation = () => {
+    const cancellation = createOperationCancellation();
+    cancellableOperations.add(cancellation);
+    return cancellation;
+  };
+
+  const cancelCancellableOperations = () => {
+    for (const cancellation of cancellableOperations) {
+      cancellation.cancel();
+    }
+
+    // A later start must queue behind the interrupting operation rather than
+    // coalescing with the start that operation just cancelled.
+    pendingStart = undefined;
+  };
+
+  const runCancellable = (
+    cancellation: OperationCancellation,
+    work: () => Promise<void>,
+  ) =>
+    run(async () => {
+      try {
+        if (!cancellation.cancelled) await work();
+      } catch (error) {
+        if (!cancellation.cancelled) throw error;
+      } finally {
+        cancellableOperations.delete(cancellation);
+      }
+    });
 
   const resolveClient = async (): Promise<ClientResolution> => {
     const probe = resolver.resolve();
@@ -143,21 +208,102 @@ export function createLanguageServerController(
     if (failure) throw failure.error;
   };
 
-  const startClient = async (candidate: LanguageServerClient) => {
-    client = candidate;
+  const disposeUnusedClient = async (candidate: LanguageServerClient) => {
     try {
-      await candidate.start();
-      started = true;
-    } catch (error) {
+      await candidate.dispose();
+    } catch {
+      // Preserve the lifecycle result that made this candidate unused.
+    }
+  };
+
+  // Cancelling a start is different from stopping a running client.  The real
+  // vscode-languageclient rejects stop()/dispose() while it is Starting, but
+  // its node adapter still uses those calls to terminate the child process.
+  // Try both operations, suppressing the expected state error; the managed
+  // client returned by client.ts guarantees its VS Code resources are released.
+  const abandonStartingClient = async (candidate: LanguageServerClient) => {
+    if (client === candidate) client = undefined;
+    started = false;
+
+    try {
+      await candidate.stop();
+    } catch {
+      // Starting clients cannot be stopped through the base client API.
+    }
+
+    await disposeUnusedClient(candidate);
+  };
+
+  const startClient = async (
+    candidate: LanguageServerClient,
+    cancellation: OperationCancellation,
+  ) => {
+    if (cancellation.cancelled) {
+      await disposeUnusedClient(candidate);
+      return;
+    }
+
+    client = candidate;
+    const completion = (async () => {
+      try {
+        await candidate.start();
+        return { state: "started" } as const;
+      } catch (error) {
+        return { state: "failed", error } as const;
+      }
+    })();
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<{ state: "timedOut" }>((resolve) => {
+      timeoutHandle = setTimeout(
+        () => resolve({ state: "timedOut" }),
+        Math.max(0, startTimeoutMilliseconds),
+      );
+    });
+    const outcome = await Promise.race([
+      completion,
+      cancellation.whenCancelled.then(() => ({ state: "cancelled" }) as const),
+      timeout,
+    ]);
+    if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+
+    const stopLateSuccessfulStart = () => {
+      void completion.then(async (lateOutcome) => {
+        if (lateOutcome.state !== "started") return;
+        try {
+          await candidate.stop();
+        } catch {
+          // The process termination scheduled during abandonment is the
+          // fallback when a late client cannot be stopped gracefully.
+        }
+        await disposeUnusedClient(candidate);
+      });
+    };
+
+    if (outcome.state === "cancelled" || outcome.state === "timedOut") {
+      stopLateSuccessfulStart();
+      await abandonStartingClient(candidate);
+      if (outcome.state === "timedOut" && !cancellation.cancelled) {
+        throw new Error(
+          `Macaulay2 Language Server did not finish starting within ${startTimeoutMilliseconds} ms.`,
+        );
+      }
+      return;
+    }
+
+    if (outcome.state === "failed") {
       client = undefined;
       started = false;
-      try {
-        await candidate.dispose();
-      } catch {
-        // Preserve the start failure for the user; disposal is best effort.
-      }
-      throw error;
+      await disposeUnusedClient(candidate);
+      if (!cancellation.cancelled) throw outcome.error;
+      return;
     }
+
+    if (cancellation.cancelled) {
+      await abandonStartingClient(candidate);
+      return;
+    }
+
+    started = true;
   };
 
   const discardClientAndReport = async (): Promise<boolean> => {
@@ -173,13 +319,23 @@ export function createLanguageServerController(
   // Build the replacement before stopping a healthy client.  A timeout (or a
   // failure to load/build the new client) therefore leaves the running server
   // alone.  A conclusive miss still tears it down before reporting the result.
-  const replaceClient = async (announceMissing: boolean) => {
+  const replaceClient = async (
+    announceMissing: boolean,
+    cancellation: OperationCancellation,
+  ) => {
     const resolved = await resolveClient();
+    if (cancellation.cancelled) {
+      if (resolved.state === "resolved") {
+        await disposeUnusedClient(resolved.client);
+      }
+      return;
+    }
+
     if (resolved.state === "timedOut") return;
 
     if (resolved.state === "missing") {
       if (!(await discardClientAndReport())) return;
-      if (announceMissing) reportNotFound();
+      if (!cancellation.cancelled && announceMissing) reportNotFound();
       return;
     }
 
@@ -187,27 +343,48 @@ export function createLanguageServerController(
       // Resolution creates a candidate before touching the healthy client so
       // load failures preserve it.  If old-client teardown fails, the unused
       // candidate still needs to be released.
-      try {
-        await resolved.client.dispose();
-      } catch {
-        // Preserve the shutdown failure already reported above.
-      }
+      await disposeUnusedClient(resolved.client);
       return;
     }
-    await startClient(resolved.client);
+
+    if (cancellation.cancelled) {
+      await disposeUnusedClient(resolved.client);
+      return;
+    }
+    await startClient(resolved.client, cancellation);
   };
 
-  const start = () =>
-    run(async () => {
+  const start = () => {
+    demanded = true;
+    if (pendingStart) return pendingStart;
+
+    const cancellation = trackCancellation();
+    const task = runCancellable(cancellation, async () => {
       if (started || missing || !isEnabled()) return;
 
       const resolved = await resolveClient();
+      if (cancellation.cancelled) {
+        if (resolved.state === "resolved") {
+          await disposeUnusedClient(resolved.client);
+        }
+        return;
+      }
       if (resolved.state !== "resolved") return;
-      await startClient(resolved.client);
+      await startClient(resolved.client, cancellation);
     });
+    pendingStart = task;
+    const clearPendingStart = () => {
+      if (pendingStart === task) pendingStart = undefined;
+    };
+    void task.then(clearPendingStart, clearPendingStart);
+    return task;
+  };
 
-  const restart = () =>
-    run(async () => {
+  const restart = () => {
+    demanded = true;
+    cancelCancellableOperations();
+    const cancellation = trackCancellation();
+    return runCancellable(cancellation, async () => {
       if (!isEnabled()) {
         reportDisabled();
         return;
@@ -215,11 +392,14 @@ export function createLanguageServerController(
 
       resolver.forget();
       missing = false;
-      await replaceClient(true);
+      await replaceClient(true, cancellation);
     });
+  };
 
-  const configurationChanged = () =>
-    run(async () => {
+  const configurationChanged = () => {
+    cancelCancellableOperations();
+    const cancellation = trackCancellation();
+    return runCancellable(cancellation, async () => {
       // Either setting can make the cached resolution stale.  Clearing it here
       // also lets re-enabling discover a server installed while disabled.
       resolver.forget();
@@ -230,12 +410,19 @@ export function createLanguageServerController(
         return;
       }
 
+      if (!demanded) return;
+
       // Setting changes are already visible user actions, but a missing server
       // remains silent here just as it is for editor-driven start().
-      await replaceClient(false);
+      await replaceClient(false, cancellation);
     });
+  };
 
-  const stop = () => run(discardClient, reportStopError);
+  const stop = () => {
+    demanded = false;
+    cancelCancellableOperations();
+    return run(discardClient, reportStopError);
+  };
 
   return {
     start,

--- a/src/backend/languageServer.ts
+++ b/src/backend/languageServer.ts
@@ -38,6 +38,7 @@ export interface LanguageServerControllerOptions {
   reportDisabled(): void;
   reportNotFound(): void;
   reportStartError(error: unknown): void;
+  reportStopError(error: unknown): void;
 }
 
 export interface LanguageServerController {
@@ -61,6 +62,7 @@ export function createLanguageServerController(
     reportDisabled,
     reportNotFound,
     reportStartError,
+    reportStopError,
   } = options;
 
   // Undefined until a resolution succeeds and a client is built for it.
@@ -77,13 +79,16 @@ export function createLanguageServerController(
   // operation is ever in flight and callers can await whatever is running.
   // Errors are reported once and never propagate: every caller discards the
   // result, and an unhandled rejection out of an editor event is not useful.
-  const run = (work: () => Promise<void>): Promise<void> => {
+  const run = (
+    work: () => Promise<void>,
+    report: (error: unknown) => void = reportStartError,
+  ): Promise<void> => {
     const token = ++pendingToken;
     const task = (async () => {
       try {
         await work();
       } catch (error) {
-        reportStartError(error);
+        report(error);
       } finally {
         // A restart that took the slot over while this was settling must keep
         // it, or a concurrent start would see an idle controller.
@@ -169,9 +174,15 @@ export function createLanguageServerController(
     });
   };
 
-  const stop = async () => {
-    if (pending) await pending;
-    await discardClient();
+  // Goes through run() like the others, so it queues behind an in-flight start
+  // instead of tearing the client out from under it, and so a failure to shut
+  // down is reported rather than left as an unhandled rejection.
+  const stop = () => {
+    const previous = pending;
+    return run(async () => {
+      if (previous) await previous;
+      await discardClient();
+    }, reportStopError);
   };
 
   return {

--- a/src/backend/test/extension.test.ts
+++ b/src/backend/test/extension.test.ts
@@ -181,6 +181,20 @@ suite("Extension Tests", function () {
     );
   });
 
+  test("every contributed command is prefixed in the palette", function () {
+    // The README documents them all as "Macaulay2: ...", which is what the
+    // category produces.  Without it a command shows up bare, next to the
+    // prefixed ones.
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(__dirname, "../../package.json"), "utf8"),
+    );
+    const uncategorized = manifest.contributes.commands
+      .filter((command: { category?: string }) => !command.category)
+      .map((command: { command: string }) => command.command);
+
+    assert.deepEqual(uncategorized, []);
+  });
+
   test("matches Macaulay2 identifiers and numeric literals as editor words", function () {
     const configurationSource = fs.readFileSync(
       path.join(__dirname, "../../language-configuration.json"),

--- a/src/backend/test/extension.test.ts
+++ b/src/backend/test/extension.test.ts
@@ -448,6 +448,7 @@ suite("Language Server Controller", function () {
       reportDisabled: () => reported.push("disabled"),
       reportNotFound: () => reported.push("notFound"),
       reportStartError: () => reported.push("startError"),
+      reportStopError: () => reported.push("stopError"),
       ...overrides,
     });
 
@@ -646,6 +647,31 @@ suite("Language Server Controller", function () {
     await harness.controller.start();
     await harness.controller.stop();
 
+    assert.deepEqual(harness.clients[0].calls, ["start", "stop", "dispose"]);
+  });
+
+  test("stop then start builds a fresh client", async function () {
+    // Turning the setting off and back on goes through stop() and start()
+    // rather than a window reload, so the second start has to work.
+    const harness = createHarness([found, found]);
+
+    await harness.controller.start();
+    await harness.controller.stop();
+    await harness.controller.start();
+
+    assert.equal(harness.clients.length, 2);
+    assert.deepEqual(harness.clients[0].calls, ["start", "stop", "dispose"]);
+    assert.deepEqual(harness.clients[1].calls, ["start"]);
+  });
+
+  test("stop queues behind an in-flight start", async function () {
+    const harness = createHarness([found]);
+
+    const starting = harness.controller.start();
+    const stopping = harness.controller.stop();
+    await Promise.all([starting, stopping]);
+
+    assert.equal(harness.clients.length, 1);
     assert.deepEqual(harness.clients[0].calls, ["start", "stop", "dispose"]);
   });
 

--- a/src/backend/test/extension.test.ts
+++ b/src/backend/test/extension.test.ts
@@ -18,6 +18,7 @@ import {
 } from "../executableSwitcher";
 import {
   CachedCommandResolver,
+  CommandExecutableResolution,
   CommandProbe,
   createCachedCommandResolver,
   getM2ExecutableResolutionDetail,
@@ -375,43 +376,43 @@ suite("Executable Switcher", function () {
 });
 
 suite("Language Server Controller", function () {
+  // One entry per client the controller builds, so a test can tell "restarted
+  // the same client" from "built a second one".
   interface FakeClient {
     start(): Thenable<void>;
     stop(): Thenable<void>;
-    restart(): Thenable<void>;
+    dispose(): void;
+    executablePath: string;
     calls: string[];
-    failStart?: unknown;
-    failRestart?: unknown;
-  }
-
-  function createFakeClient(): FakeClient {
-    const client: FakeClient = {
-      calls: [],
-      start() {
-        client.calls.push("start");
-        return client.failStart
-          ? Promise.reject(client.failStart)
-          : Promise.resolve();
-      },
-      stop() {
-        client.calls.push("stop");
-        return Promise.resolve();
-      },
-      restart() {
-        client.calls.push("restart");
-        return client.failRestart
-          ? Promise.reject(client.failRestart)
-          : Promise.resolve();
-      },
-    };
-    return client;
   }
 
   function createHarness(
     probes: CommandProbe[],
     overrides: Partial<LanguageServerControllerOptions> = {},
   ) {
-    const client = createFakeClient();
+    const clients: FakeClient[] = [];
+    let failStart: unknown;
+
+    const createClient = (resolution: CommandExecutableResolution) => {
+      const client: FakeClient = {
+        executablePath: resolution.executablePath,
+        calls: [],
+        start() {
+          client.calls.push("start");
+          return failStart ? Promise.reject(failStart) : Promise.resolve();
+        },
+        stop() {
+          client.calls.push("stop");
+          return Promise.resolve();
+        },
+        dispose() {
+          client.calls.push("dispose");
+        },
+      };
+      clients.push(client);
+      return Promise.resolve(client);
+    };
+
     let probeCount = 0;
     // Runs out of scripted answers rather than repeating the last one, so a
     // controller that probes more often than expected fails loudly.
@@ -427,9 +428,8 @@ suite("Language Server Controller", function () {
 
     const reported: string[] = [];
     const controller = createLanguageServerController({
-      client,
+      createClient,
       resolver,
-      configure: () => {},
       isEnabled: () => true,
       reportDisabled: () => reported.push("disabled"),
       reportNotFound: () => reported.push("notFound"),
@@ -438,11 +438,19 @@ suite("Language Server Controller", function () {
     });
 
     return {
-      client,
+      clients,
       controller,
       reported,
+      failWith(error: unknown) {
+        failStart = error;
+      },
       get probeCount() {
         return probeCount;
+      },
+      // Flattened call log across every client built, which is what most of
+      // these tests actually care about.
+      get calls() {
+        return clients.flatMap((client) => client.calls);
       },
     };
   }
@@ -450,6 +458,13 @@ suite("Language Server Controller", function () {
   const found: CommandProbe = {
     resolution: {
       executablePath: "/usr/bin/M2-language-server",
+      source: "PATH",
+    },
+    timedOut: false,
+  };
+  const moved: CommandProbe = {
+    resolution: {
+      executablePath: "/opt/bin/M2-language-server",
       source: "PATH",
     },
     timedOut: false,
@@ -468,26 +483,37 @@ suite("Language Server Controller", function () {
     await harness.controller.start();
 
     assert.equal(harness.probeCount, 1);
-    assert.deepEqual(harness.client.calls, []);
+    assert.deepEqual(harness.clients, []);
   });
 
-  test("probes once when the language server starts", async function () {
+  test("builds no client when the language server is not installed", async function () {
+    // vscode-languageclient is imported by createClient, so never calling it
+    // is what keeps it out of activation for most users.
+    const harness = createHarness([notFound]);
+
+    await harness.controller.start();
+
+    assert.deepEqual(harness.clients, []);
+  });
+
+  test("builds no client while disabled", async function () {
+    const harness = createHarness([], { isEnabled: () => false });
+
+    await harness.controller.start();
+
+    assert.equal(harness.probeCount, 0);
+    assert.deepEqual(harness.clients, []);
+  });
+
+  test("probes once and builds one client when the server starts", async function () {
     const harness = createHarness([found]);
 
     await harness.controller.start();
     await harness.controller.start();
 
     assert.equal(harness.probeCount, 1);
-    assert.deepEqual(harness.client.calls, ["start"]);
-  });
-
-  test("does not probe while disabled", async function () {
-    const harness = createHarness([], { isEnabled: () => false });
-
-    await harness.controller.start();
-
-    assert.equal(harness.probeCount, 0);
-    assert.deepEqual(harness.client.calls, []);
+    assert.equal(harness.clients.length, 1);
+    assert.deepEqual(harness.calls, ["start"]);
   });
 
   test("coalesces concurrent starts into one", async function () {
@@ -500,7 +526,8 @@ suite("Language Server Controller", function () {
     ]);
 
     assert.equal(harness.probeCount, 1);
-    assert.deepEqual(harness.client.calls, ["start"]);
+    assert.equal(harness.clients.length, 1);
+    assert.deepEqual(harness.calls, ["start"]);
   });
 
   test("does not cache a probe that timed out", async function () {
@@ -509,34 +536,41 @@ suite("Language Server Controller", function () {
     const harness = createHarness([timedOut, found]);
 
     await harness.controller.start();
-    assert.deepEqual(harness.client.calls, []);
+    assert.deepEqual(harness.clients, []);
 
     await harness.controller.start();
 
     assert.equal(harness.probeCount, 2);
-    assert.deepEqual(harness.client.calls, ["start"]);
+    assert.deepEqual(harness.calls, ["start"]);
   });
 
   test("restart re-probes and starts a server installed since activation", async function () {
     const harness = createHarness([notFound, found]);
 
     await harness.controller.start();
-    assert.deepEqual(harness.client.calls, []);
+    assert.deepEqual(harness.clients, []);
 
     await harness.controller.restart();
 
     assert.equal(harness.probeCount, 2);
-    assert.deepEqual(harness.client.calls, ["start"]);
+    assert.deepEqual(harness.calls, ["start"]);
     assert.deepEqual(harness.reported, []);
   });
 
-  test("restart of a running server restarts the client", async function () {
-    const harness = createHarness([found, found]);
+  test("restart builds a new client rather than reusing the old one", async function () {
+    // The executable path is baked into a client at construction, so a restart
+    // that finds the server somewhere else has to build a fresh one.
+    const harness = createHarness([found, moved]);
 
     await harness.controller.start();
     await harness.controller.restart();
 
-    assert.deepEqual(harness.client.calls, ["start", "restart"]);
+    assert.deepEqual(
+      harness.clients.map((client) => client.executablePath),
+      ["/usr/bin/M2-language-server", "/opt/bin/M2-language-server"],
+    );
+    assert.deepEqual(harness.clients[0].calls, ["start", "stop", "dispose"]);
+    assert.deepEqual(harness.clients[1].calls, ["start"]);
   });
 
   test("restart reports when the language server is disabled", async function () {
@@ -556,14 +590,15 @@ suite("Language Server Controller", function () {
     await harness.controller.start();
     await harness.controller.restart();
 
-    assert.deepEqual(harness.client.calls, ["start", "stop"]);
+    assert.deepEqual(harness.clients[0].calls, ["start", "stop", "dispose"]);
     assert.deepEqual(harness.reported, ["notFound"]);
 
     await harness.controller.restart();
-    assert.deepEqual(harness.client.calls, ["start", "stop", "start"]);
+    assert.equal(harness.clients.length, 2);
+    assert.deepEqual(harness.clients[1].calls, ["start"]);
   });
 
-  test("a start racing a restart does not start the client twice", async function () {
+  test("a start racing a restart does not start a second client", async function () {
     const harness = createHarness([found, found]);
 
     await harness.controller.start();
@@ -572,36 +607,41 @@ suite("Language Server Controller", function () {
     const racing = harness.controller.start();
     await Promise.all([restarting, racing]);
 
-    assert.deepEqual(harness.client.calls, ["start", "restart"]);
+    assert.equal(harness.clients.length, 2);
+    assert.deepEqual(harness.clients[1].calls, ["start"]);
     assert.deepEqual(harness.reported, []);
   });
 
   test("reports a failed start once and allows a later retry", async function () {
     const harness = createHarness([found, found]);
-    harness.client.failStart = new Error("boom");
+    harness.failWith(new Error("boom"));
 
     await harness.controller.start();
     assert.deepEqual(harness.reported, ["startError"]);
 
-    harness.client.failStart = undefined;
+    harness.failWith(undefined);
     await harness.controller.restart();
 
-    assert.deepEqual(harness.client.calls, ["start", "start"]);
     assert.deepEqual(harness.reported, ["startError"]);
+    assert.deepEqual(harness.clients[1].calls, ["start"]);
   });
 
-  test("a failed restart leaves the server startable again", async function () {
-    const harness = createHarness([found, found, found]);
+  test("stop shuts the running client down", async function () {
+    const harness = createHarness([found]);
+
     await harness.controller.start();
+    await harness.controller.stop();
 
-    harness.client.failRestart = new Error("boom");
-    await harness.controller.restart();
-    assert.deepEqual(harness.reported, ["startError"]);
+    assert.deepEqual(harness.clients[0].calls, ["start", "stop", "dispose"]);
+  });
 
-    harness.client.failRestart = undefined;
-    await harness.controller.restart();
+  test("stop is harmless when nothing ever started", async function () {
+    const harness = createHarness([notFound]);
 
-    assert.deepEqual(harness.client.calls, ["start", "restart", "start"]);
+    await harness.controller.start();
+    await harness.controller.stop();
+
+    assert.deepEqual(harness.clients, []);
   });
 });
 

--- a/src/backend/test/extension.test.ts
+++ b/src/backend/test/extension.test.ts
@@ -567,6 +567,8 @@ suite("Language Server Controller", function () {
 
     assert.equal(harness.probeCount, 1);
     assert.deepEqual(harness.clients, []);
+    // Silent: nobody asked for a language server by opening a file.
+    assert.deepEqual(harness.reported, []);
   });
 
   test("builds no client when the language server is not installed", async function () {
@@ -654,6 +656,19 @@ suite("Language Server Controller", function () {
     );
     assert.deepEqual(harness.clients[0].calls, ["start", "stop", "dispose"]);
     assert.deepEqual(harness.clients[1].calls, ["start"]);
+  });
+
+  test("restart says so when there is nothing to restart", async function () {
+    // The counterpart to start() staying silent: a restart is an explicit
+    // request, so it gets an answer every time rather than failing quietly.
+    const harness = createHarness([notFound, notFound]);
+
+    await harness.controller.restart();
+    assert.deepEqual(harness.reported, ["notFound"]);
+
+    await harness.controller.restart();
+    assert.deepEqual(harness.reported, ["notFound", "notFound"]);
+    assert.deepEqual(harness.clients, []);
   });
 
   test("restart reports when the language server is disabled", async function () {

--- a/src/backend/test/extension.test.ts
+++ b/src/backend/test/extension.test.ts
@@ -21,6 +21,7 @@ import {
   CommandExecutableResolution,
   CommandProbe,
   createCachedCommandResolver,
+  probeConfiguredCommand,
   getM2ExecutableResolutionDetail,
   getM2LaunchConfiguration,
   M2ExecutableResolution,
@@ -385,6 +386,73 @@ suite("Executable Switcher", function () {
         wslExecutablePath: "/usr/bin/M2",
       }),
       "$(terminal) M2: WSL:/usr/bin/M2",
+    );
+  });
+});
+
+suite("Configured Command Resolution", function () {
+  const autoDetected: CommandProbe = {
+    resolution: {
+      executablePath: "/usr/bin/M2-language-server",
+      source: "PATH",
+    },
+    timedOut: false,
+  };
+
+  test("a configured path wins over auto-detection", function () {
+    let probed = false;
+    const probe = probeConfiguredCommand(
+      "/opt/M2-language-server",
+      "M2-language-server",
+      () => {
+        probed = true;
+        return autoDetected;
+      },
+    );
+
+    assert.deepEqual(probe, {
+      resolution: {
+        executablePath: "/opt/M2-language-server",
+        source: "setting",
+      },
+      timedOut: false,
+    });
+    // Not just overridden afterwards: the probe must not run at all, since it
+    // is the expensive part.
+    assert.equal(probed, false);
+  });
+
+  test("an empty or whitespace setting falls back to auto-detection", function () {
+    for (const configured of [undefined, "", "   "]) {
+      assert.deepEqual(
+        probeConfiguredCommand(
+          configured,
+          "M2-language-server",
+          () => autoDetected,
+        ),
+        autoDetected,
+      );
+    }
+  });
+
+  test("a configured path is trimmed but not otherwise checked", function () {
+    // Taken as given, like macaulay2.executablePath, so a wrong path fails at
+    // startup naming itself rather than silently auto-detecting something else.
+    assert.deepEqual(
+      probeConfiguredCommand(
+        "  /nonexistent/M2-language-server  ",
+        "M2-language-server",
+        () => {
+          throw new Error("should not auto-detect");
+        },
+      ),
+      {
+        resolution: {
+          executablePath: "/nonexistent/M2-language-server",
+          source: "setting",
+        },
+        timedOut: false,
+      },
     );
   });
 });

--- a/src/backend/test/extension.test.ts
+++ b/src/backend/test/extension.test.ts
@@ -47,6 +47,7 @@ import {
   createLanguageServerController,
   LanguageServerControllerOptions,
 } from "../languageServer";
+import { createGuardedOutputChannel, manageLanguageClient } from "../client";
 
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
@@ -183,12 +184,12 @@ suite("Extension Tests", function () {
         "editor.indentSize": 4,
       },
     );
-    assert.equal(
+    const languageServerPath =
       manifest.contributes.configuration.properties[
         "macaulay2.languageServerPath"
-      ].scope,
-      "machine-overridable",
-    );
+      ];
+    assert.equal(languageServerPath.scope, "window");
+    assert.equal(languageServerPath.ignoreSync, true);
   });
 
   test("every contributed command is prefixed in the palette", function () {
@@ -560,6 +561,168 @@ suite("Command Executable Resolution", function () {
   });
 });
 
+suite("Managed Language Client", function () {
+  test("releases resources when the raw client cannot dispose", async function () {
+    let diagnosticDisposals = 0;
+    let outputDisposals = 0;
+    const output: string[] = [];
+    let rawDisposals = 0;
+    let cancellations = 0;
+    let rawDisposeTimeout: number | undefined;
+    const outputChannel = createGuardedOutputChannel({
+      name: "test",
+      append(value: string) {
+        output.push(value);
+      },
+      appendLine(value: string) {
+        output.push(`${value}\n`);
+      },
+      replace(value: string) {
+        output.splice(0, output.length, value);
+      },
+      clear() {
+        output.splice(0);
+      },
+      show() {},
+      hide() {},
+      dispose() {
+        outputDisposals += 1;
+      },
+    });
+    const managed = manageLanguageClient(
+      {
+        diagnostics: {
+          dispose() {
+            diagnosticDisposals += 1;
+          },
+        },
+        start: () => Promise.reject(new Error("start failed")),
+        stop: () => Promise.resolve(),
+        cancelStart() {
+          cancellations += 1;
+        },
+        dispose(timeout?: number) {
+          rawDisposals += 1;
+          rawDisposeTimeout = timeout;
+          return Promise.reject(new Error("raw dispose failed"));
+        },
+      },
+      outputChannel,
+      10,
+    );
+
+    outputChannel.append("before disposal");
+    await assert.rejects(async () => managed.start(), /start failed/);
+    const disposing = managed.dispose();
+    await Promise.resolve();
+    assert.equal(outputDisposals, 0);
+    await disposing;
+    await managed.dispose();
+    outputChannel.append("late callback");
+
+    assert.equal(rawDisposals, 1);
+    assert.equal(cancellations, 1);
+    assert.equal(rawDisposeTimeout, 0);
+    assert.equal(diagnosticDisposals, 1);
+    assert.equal(outputDisposals, 1);
+    assert.deepEqual(output, ["before disposal"]);
+  });
+
+  test("stops a startup that succeeds during disposal", async function () {
+    let releaseStart: () => void;
+    const startGate = new Promise<void>((resolve) => {
+      releaseStart = resolve;
+    });
+    let stopCalls = 0;
+    let outputDisposals = 0;
+    const managed = manageLanguageClient(
+      {
+        diagnostics: undefined,
+        start: () => startGate,
+        stop() {
+          stopCalls += 1;
+          assert.equal(outputDisposals, 0);
+          return Promise.resolve();
+        },
+        dispose: () => Promise.reject(new Error("still starting")),
+      },
+      {
+        dispose() {
+          outputDisposals += 1;
+        },
+      },
+      20,
+    );
+
+    const starting = managed.start();
+    const disposing = managed.dispose();
+    releaseStart();
+    await Promise.all([starting, disposing]);
+
+    assert.equal(stopCalls, 1);
+    assert.equal(outputDisposals, 1);
+  });
+
+  test("bounds disposal when startup never settles", async function () {
+    this.timeout(1000);
+
+    let outputDisposals = 0;
+    const managed = manageLanguageClient(
+      {
+        diagnostics: undefined,
+        start: () => new Promise<void>(() => {}),
+        stop: () => Promise.reject(new Error("still starting")),
+        dispose: () => Promise.reject(new Error("still starting")),
+      },
+      {
+        dispose() {
+          outputDisposals += 1;
+        },
+      },
+      10,
+    );
+
+    void managed.start();
+    await managed.dispose();
+
+    assert.equal(outputDisposals, 1);
+  });
+
+  test("waits for process termination after stop rejects", async function () {
+    this.timeout(1000);
+
+    let outputDisposals = 0;
+    let cancellations = 0;
+    const managed = manageLanguageClient(
+      {
+        diagnostics: undefined,
+        start: () => Promise.resolve(),
+        stop: () => Promise.reject(new Error("shutdown timed out")),
+        dispose: () => Promise.resolve(),
+        cancelStart() {
+          cancellations += 1;
+        },
+      },
+      {
+        dispose() {
+          outputDisposals += 1;
+        },
+      },
+      10,
+    );
+
+    await managed.start();
+    await assert.rejects(async () => managed.stop(), /shutdown timed out/);
+    const disposing = managed.dispose();
+    await Promise.resolve();
+    assert.equal(outputDisposals, 0);
+    await disposing;
+
+    assert.equal(cancellations, 1);
+    assert.equal(outputDisposals, 1);
+  });
+});
+
 suite("Language Server Controller", function () {
   // One entry per client the controller builds, so a test can tell "restarted
   // the same client" from "built a second one".
@@ -579,6 +742,7 @@ suite("Language Server Controller", function () {
     let failCreate: unknown;
     let failStart: unknown;
     let failStop: unknown;
+    let startHook: (() => Thenable<void> | void) | undefined;
     let stopHook: (() => Thenable<void> | void) | undefined;
 
     const createClient = async (resolution: CommandExecutableResolution) => {
@@ -589,6 +753,7 @@ suite("Language Server Controller", function () {
         calls: [],
         async start() {
           client.calls.push("start");
+          if (startHook) await startHook();
           if (failStart !== undefined) throw failStart;
         },
         async stop() {
@@ -607,7 +772,7 @@ suite("Language Server Controller", function () {
     let probeCount = 0;
     // Runs out of scripted answers rather than repeating the last one, so a
     // controller that probes more often than expected fails loudly.
-    const resolver: CachedCommandResolver = createCachedCommandResolver(
+    const cachedResolver = createCachedCommandResolver(
       "M2-language-server",
       () => {
         const probe = probes[probeCount];
@@ -616,6 +781,14 @@ suite("Language Server Controller", function () {
         return probe;
       },
     );
+    let forgetCount = 0;
+    const resolver: CachedCommandResolver = {
+      resolve: () => cachedResolver.resolve(),
+      forget() {
+        forgetCount += 1;
+        cachedResolver.forget();
+      },
+    };
 
     const reported: string[] = [];
     const controller = createLanguageServerController({
@@ -642,11 +815,17 @@ suite("Language Server Controller", function () {
       failStopWith(error: unknown) {
         failStop = error;
       },
+      runDuringStart(hook: (() => Thenable<void> | void) | undefined) {
+        startHook = hook;
+      },
       runDuringStop(hook: (() => Thenable<void> | void) | undefined) {
         stopHook = hook;
       },
       get probeCount() {
         return probeCount;
+      },
+      get forgetCount() {
+        return forgetCount;
       },
       // Flattened call log across every client built, which is what most of
       // these tests actually care about.
@@ -731,6 +910,22 @@ suite("Language Server Controller", function () {
     assert.equal(harness.probeCount, 1);
     assert.equal(harness.clients.length, 1);
     assert.deepEqual(harness.calls, ["start"]);
+  });
+
+  test("coalesces concurrent starts when startup rejects", async function () {
+    const harness = createHarness([found]);
+    harness.failStartWith(new Error("boom"));
+
+    await Promise.all([
+      harness.controller.start(),
+      harness.controller.start(),
+      harness.controller.start(),
+    ]);
+
+    assert.equal(harness.probeCount, 1);
+    assert.equal(harness.clients.length, 1);
+    assert.deepEqual(harness.calls, ["start", "dispose"]);
+    assert.deepEqual(harness.reported, ["startError"]);
   });
 
   test("does not repeat a timed-out probe from editor starts", async function () {
@@ -959,6 +1154,26 @@ suite("Language Server Controller", function () {
     assert.deepEqual(harness.clients[1].calls, ["start"]);
   });
 
+  test("a configuration change before first start only invalidates", async function () {
+    const harness = createHarness([moved]);
+
+    await harness.controller.configurationChanged();
+
+    assert.equal(harness.forgetCount, 1);
+    assert.equal(harness.probeCount, 0);
+    assert.deepEqual(harness.clients, []);
+
+    await harness.controller.start();
+
+    assert.equal(harness.probeCount, 1);
+    assert.equal(harness.clients.length, 1);
+    assert.equal(
+      harness.clients[0].executablePath,
+      "/opt/bin/M2-language-server",
+    );
+    assert.deepEqual(harness.clients[0].calls, ["start"]);
+  });
+
   test("configuration changes while disabled invalidate without probing", async function () {
     let enabled = true;
     const harness = createHarness([found, moved], {
@@ -1016,7 +1231,7 @@ suite("Language Server Controller", function () {
     assert.deepEqual(harness.reported, []);
   });
 
-  test("stop queues behind an in-flight start", async function () {
+  test("stop cancels a launch before the client starts", async function () {
     const harness = createHarness([found]);
 
     const starting = harness.controller.start();
@@ -1024,7 +1239,166 @@ suite("Language Server Controller", function () {
     await Promise.all([starting, stopping]);
 
     assert.equal(harness.clients.length, 1);
+    assert.deepEqual(harness.clients[0].calls, ["dispose"]);
+  });
+
+  test("stop suppresses a late client-construction failure", async function () {
+    let markConstructionEntered: () => void;
+    let releaseConstruction: () => void;
+    const constructionEntered = new Promise<void>((resolve) => {
+      markConstructionEntered = resolve;
+    });
+    const constructionGate = new Promise<void>((resolve) => {
+      releaseConstruction = resolve;
+    });
+    const harness = createHarness([found], {
+      createClient: async () => {
+        markConstructionEntered();
+        await constructionGate;
+        throw new Error("lazy import failed");
+      },
+    });
+
+    const starting = harness.controller.start();
+    await constructionEntered;
+    const stopping = harness.controller.stop();
+    releaseConstruction();
+    await Promise.all([starting, stopping]);
+
+    assert.deepEqual(harness.reported, []);
+  });
+
+  test("stop tears down a client whose start never settles", async function () {
+    this.timeout(1000);
+
+    const harness = createHarness([found]);
+    let markStartEntered: () => void;
+    const startEntered = new Promise<void>((resolve) => {
+      markStartEntered = resolve;
+    });
+    const startNeverSettles = new Promise<void>(() => {});
+    harness.runDuringStart(() => {
+      markStartEntered();
+      return startNeverSettles;
+    });
+
+    void harness.controller.start();
+    await startEntered;
+    await harness.controller.stop();
+
     assert.deepEqual(harness.clients[0].calls, ["start", "stop", "dispose"]);
+  });
+
+  test("stop tears down a cancelled client again if startup finishes late", async function () {
+    this.timeout(1000);
+
+    const harness = createHarness([found]);
+    let markStartEntered: () => void;
+    let releaseStart: () => void;
+    let markLateStop: () => void;
+    const startEntered = new Promise<void>((resolve) => {
+      markStartEntered = resolve;
+    });
+    const startGate = new Promise<void>((resolve) => {
+      releaseStart = resolve;
+    });
+    const lateStop = new Promise<void>((resolve) => {
+      markLateStop = resolve;
+    });
+    let stopCount = 0;
+    harness.runDuringStart(() => {
+      markStartEntered();
+      return startGate;
+    });
+    harness.runDuringStop(() => {
+      stopCount += 1;
+      if (stopCount === 2) markLateStop();
+    });
+
+    void harness.controller.start();
+    await startEntered;
+    await harness.controller.stop();
+    releaseStart();
+    await lateStop;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    assert.deepEqual(harness.clients[0].calls, [
+      "start",
+      "stop",
+      "dispose",
+      "stop",
+      "dispose",
+    ]);
+  });
+
+  test("a configuration change replaces a client whose start never settles", async function () {
+    this.timeout(1000);
+
+    const harness = createHarness([found, moved]);
+    let markStartEntered: () => void;
+    const startEntered = new Promise<void>((resolve) => {
+      markStartEntered = resolve;
+    });
+    harness.runDuringStart(() => {
+      harness.runDuringStart(undefined);
+      markStartEntered();
+      return new Promise<void>(() => {});
+    });
+
+    void harness.controller.start();
+    await startEntered;
+    await harness.controller.configurationChanged();
+
+    assert.deepEqual(harness.clients[0].calls, ["start", "stop", "dispose"]);
+    assert.equal(
+      harness.clients[1].executablePath,
+      moved.resolution.executablePath,
+    );
+    assert.deepEqual(harness.clients[1].calls, ["start"]);
+  });
+
+  test("times out a client whose start never settles", async function () {
+    this.timeout(1000);
+
+    const harness = createHarness([found], {
+      startTimeoutMilliseconds: 10,
+    });
+    harness.runDuringStart(() => new Promise<void>(() => {}));
+
+    await harness.controller.start();
+
+    assert.deepEqual(harness.clients[0].calls, ["start", "stop", "dispose"]);
+    assert.deepEqual(harness.reported, ["startError"]);
+  });
+
+  test("does not report a timeout superseded by stop", async function () {
+    this.timeout(1000);
+
+    const harness = createHarness([found], {
+      startTimeoutMilliseconds: 10,
+    });
+    let markStopEntered: () => void;
+    let releaseStop: () => void;
+    const stopEntered = new Promise<void>((resolve) => {
+      markStopEntered = resolve;
+    });
+    const stopGate = new Promise<void>((resolve) => {
+      releaseStop = resolve;
+    });
+    harness.runDuringStart(() => new Promise<void>(() => {}));
+    harness.runDuringStop(() => {
+      markStopEntered();
+      return stopGate;
+    });
+
+    const starting = harness.controller.start();
+    await stopEntered;
+    const stopping = harness.controller.stop();
+    releaseStop();
+    await Promise.all([starting, stopping]);
+
+    assert.deepEqual(harness.clients[0].calls, ["start", "stop", "dispose"]);
+    assert.deepEqual(harness.reported, []);
   });
 
   test("stop still disposes and reports when shutdown rejects", async function () {


### PR DESCRIPTION
Third follow-up from the review of #29 — item 3.

**Stacked on #30**, which extracted the controller this builds on. Based on `fix-language-server-discovery` so the diff shows only this change; GitHub will retarget to `development` when #30 merges.

## The problem

```ts
const serverOptions: Executable = { command: "M2-language-server" };
export function configureLanguageServer(command, args) {
  serverOptions.command = command;
  serverOptions.args = args;
}
export default new LanguageClient(..., serverOptions as ServerOptions, clientOptions);
```

**Eager construction.** `extension.ts` imported this at the top, so `vscode-languageclient` was loaded and a client constructed on every activation — including when `enableLanguageServer` is `false`, and with `onStartupFinished` in `activationEvents` that means every window.

**Mutation after construction.** Reassigning `serverOptions` post-construction works only because `LanguageClient` reads the field at `start()` rather than copying it. That is an implementation detail of v9, not part of its contract, and the `as ServerOptions` cast hides that the object is aliased.

## The fix

`createLanguageClient(resolution)` builds a client from one resolution and never mutates it. The controller calls it through a `createClient` hook backed by a dynamic `import("./client")` — the same pattern `completionProviders` already uses here.

I checked this in the built bundle rather than assuming it:

```
createClient: async (resolution) => (await Promise.resolve().then(() => (init_client(), client_exports))).createLanguageClient(resolution)
```

`init_client()` has exactly one call site, that one, and `require_node3()` — the entry to the whole `vscode-languageclient` tree — is reached only from inside it. So on activation none of that tree initializes.

Because a client is now pinned to the executable it was built from, restart discards the old client and builds a new one rather than repointing it. That is also the more correct behavior: the executable really can move between restarts, which is the reason the command re-probes at all.

The controller consequently owns the client's lifetime, so it grows `stop()` for `deactivate()` and `dispose()` for `context.subscriptions`, and the separate `configure()` hook is gone.

## Testing

`npm test` — 80 passing, up from 78 on #30. The controller suite was reworked so the fake records one entry per client built, which lets the tests distinguish "restarted the same client" from "built a second one". New cases: no client is built when the server is missing or the setting is off (the property that keeps `vscode-languageclient` out of activation), restart builds a client at the new path and stops and disposes the old one, and `stop()` both shuts a running client down and is harmless when nothing started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QruFMGMFf7esJacqKJr1ya
