### PR TITLE
Language server lifecycle and settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Use `F12` or run **Macaulay2: Start M2 REPL** from the Command Palette to start 
 - An integrated Macaulay2 REPL in a VS Code webview.
 - Terminal-backed evaluation in a standard VS Code terminal through a separate command/keybinding.
 - Automatic `M2` executable detection on macOS and Windows, including WSL installs on Windows, with a manual override when needed.
-- Language server support via `M2-language-server` for additional editor features when installed.
+- Language server support via `M2-language-server` for additional editor features when installed, found automatically or pointed at with a setting.
 
 ![Syntax highlighting](https://user-images.githubusercontent.com/186528/54696704-990e3480-4b2c-11e9-9376-3106aa64d618.png)
 
@@ -62,6 +62,7 @@ There is no REPL target setting. To send evaluation to the terminal from a keybi
 | `macaulay2.webviewTopLevelMode` | `webapp` | Choose the webview REPL top-level output mode: `webapp` or `standard`. |
 | `macaulay2.webviewMatrixKatexMaxEntries` | `2500` | Maximum matrix entries the webview REPL renders with KaTeX. Larger matrices use Macaulay2 net output, matching `topLevelMode = Standard`. |
 | `macaulay2.enableLanguageServer` | `true` | Enable the Macaulay2 Language Server. Requires `M2-language-server` to be installed; skipped silently if not found. |
+| `macaulay2.languageServerPath` | `""` | Absolute path to the `M2-language-server` executable. Leave empty to detect it automatically. |
 
 ## Regenerating the grammars
 

--- a/package.json
+++ b/package.json
@@ -111,6 +111,12 @@
 					"description": "Enable the Macaulay2 Language Server for enhanced language support (hover, signature help, etc.). Requires M2-language-server to be installed.",
 					"scope": "window"
 				},
+				"macaulay2.languageServerPath": {
+					"type": "string",
+					"default": "",
+					"description": "Absolute path to the M2-language-server executable. Leave empty to detect it automatically.",
+					"scope": "window"
+				},
 				"macaulay2.executablePath": {
 					"type": "string",
 					"default": "",

--- a/package.json
+++ b/package.json
@@ -26,32 +26,39 @@
 		"commands": [
 			{
 				"command": "macaulay2.startREPL",
-				"title": "Start M2 REPL"
+				"title": "Start M2 REPL",
+				"category": "Macaulay2"
 			},
 			{
 				"command": "macaulay2.startTerminal",
-				"title": "Start M2 Terminal"
+				"title": "Start M2 Terminal",
+				"category": "Macaulay2"
 			},
 			{
 				"command": "macaulay2.sendToWebview",
-				"title": "Send Line or Selection to Macaulay2 Webview"
+				"title": "Send Line or Selection to Macaulay2 Webview",
+				"category": "Macaulay2"
 			},
 			{
 				"command": "macaulay2.sendToTerminal",
-				"title": "Send Line or Selection to Macaulay2 Terminal"
+				"title": "Send Line or Selection to Macaulay2 Terminal",
+				"category": "Macaulay2"
 			},
 			{
 				"command": "macaulay2.runFile",
 				"title": "Run Macaulay2 File",
+				"category": "Macaulay2",
 				"icon": "$(play)"
 			},
 			{
 				"command": "macaulay2.interruptREPL",
-				"title": "Interrupt M2 Computation"
+				"title": "Interrupt M2 Computation",
+				"category": "Macaulay2"
 			},
 			{
 				"command": "macaulay2.selectExecutablePath",
-				"title": "Select M2 Executable"
+				"title": "Select M2 Executable",
+				"category": "Macaulay2"
 			},
 			{
 				"command": "macaulay2.restartLanguageServer",

--- a/src/backend/executablePath.ts
+++ b/src/backend/executablePath.ts
@@ -90,6 +90,29 @@ export function createCachedCommandResolver(
   };
 }
 
+/**
+ * Resolve a command, letting a configured path win outright.
+ *
+ * Mirrors how resolveM2Executable treats macaulay2.executablePath: the path is
+ * taken as given rather than checked, so a wrong one surfaces as a start
+ * failure naming the path instead of silently falling back to auto-detection.
+ */
+export function probeConfiguredCommand(
+  configuredPath: string | undefined,
+  command: string,
+  probe: (command: string) => CommandProbe = probeCommandExecutable,
+): CommandProbe {
+  const configured = configuredPath?.trim();
+  if (configured) {
+    return {
+      resolution: { executablePath: configured, source: "setting" },
+      timedOut: false,
+    };
+  }
+
+  return probe(command);
+}
+
 export function resolveCommandExecutable(
   command: string,
 ): CommandExecutableResolution | undefined {

--- a/src/backend/executablePath.ts
+++ b/src/backend/executablePath.ts
@@ -34,6 +34,30 @@ interface ShellProbe {
   timedOut: boolean;
 }
 
+export interface ShellCommandResult {
+  output?: string;
+  timedOut: boolean;
+}
+
+interface ShellCommandExecutionOptions {
+  encoding: "utf8";
+  stdio: ["ignore", "pipe", "ignore"];
+  timeout?: number;
+  killSignal: "SIGKILL";
+}
+
+export type ShellCommandExecutor = (
+  executablePath: string,
+  args: string[],
+  options: ShellCommandExecutionOptions,
+) => string;
+
+export type ShellCommandRunner = (
+  executablePath: string,
+  args: string[],
+  timeout?: number,
+) => ShellCommandResult;
+
 export interface CachedCommandResolver {
   // Returns the probe rather than just the resolution: callers that stop
   // asking after a negative answer need to know whether it was conclusive.
@@ -56,12 +80,10 @@ const shellProbeTimeoutMilliseconds = 5000;
  * case is the one that pays it every single time -- there is no successful
  * lookup to stop the retries.
  *
- * A probe that timed out is deliberately *not* remembered.  The command may be
- * installed behind a shell that was merely slow, and caching that answer would
- * turn one unlucky probe into a session-long verdict.
- *
- * `forget` exists so an explicit user action can pick up an executable that was
- * installed after the extension activated.
+ * Timeouts are remembered too.  Retrying a synchronous probe from every editor
+ * event would replace one unlucky delay with a five-second stall on every tab
+ * switch.  `forget` is the explicit retry path, both for a timeout and for an
+ * executable installed after the extension activated.
  */
 export function createCachedCommandResolver(
   command: string,
@@ -77,10 +99,6 @@ export function createCachedCommandResolver(
       }
 
       const result = probe(command);
-      if (!result.resolution && result.timedOut) {
-        return result;
-      }
-
       cached = { probe: result };
       return result;
     },
@@ -100,8 +118,8 @@ export function resolveCommandExecutable(
  * Resolve a command, reporting whether a shell probe ran out of time.
  *
  * A timeout is not the same answer as "not installed" -- the command may well
- * be there behind a shell that was merely slow -- so callers that remember a
- * negative result need to be able to decline to remember this one.
+ * be there behind a shell that was merely slow -- so callers need to preserve
+ * that distinction even when they cache the result until an explicit retry.
  */
 export function probeCommandExecutable(command: string): CommandProbe {
   const fromPath = findCommandOnPath(command);
@@ -113,23 +131,7 @@ export function probeCommandExecutable(command: string): CommandProbe {
   }
 
   if (process.platform === "win32") {
-    const fromCygwinShell = resolveCommandWithCygwinShell(command);
-    if (fromCygwinShell.executablePath) {
-      return {
-        resolution: {
-          executablePath: fromCygwinShell.executablePath,
-          source: "Cygwin shell",
-        },
-        timedOut: false,
-      };
-    }
-
-    const fromWsl = resolveCommandWithWsl(command);
-    if (fromWsl) {
-      return { resolution: fromWsl, timedOut: false };
-    }
-
-    return { timedOut: fromCygwinShell.timedOut };
+    return probeWindowsCommandExecutable(command);
   }
 
   const fromLoginShell = resolveCommandWithLoginShell(command);
@@ -144,6 +146,30 @@ export function probeCommandExecutable(command: string): CommandProbe {
   }
 
   return { timedOut: fromLoginShell.timedOut };
+}
+
+export function probeWindowsCommandExecutable(
+  command: string,
+  probeCygwin: (command: string) => ShellProbe = resolveCommandWithCygwinShell,
+  probeWsl: (command: string) => CommandProbe = probeCommandWithWsl,
+): CommandProbe {
+  const fromCygwinShell = probeCygwin(command);
+  if (fromCygwinShell.executablePath) {
+    return {
+      resolution: {
+        executablePath: fromCygwinShell.executablePath,
+        source: "Cygwin shell",
+      },
+      timedOut: false,
+    };
+  }
+
+  const fromWsl = probeWsl(command);
+  if (fromWsl.resolution) {
+    return fromWsl;
+  }
+
+  return { timedOut: fromCygwinShell.timedOut || fromWsl.timedOut };
 }
 
 export function resolveM2Executable(
@@ -461,7 +487,7 @@ function resolveCommandWithCygwinShell(command: string): ShellProbe {
 }
 
 function resolveWithWsl(): M2ExecutableResolution | undefined {
-  const resolved = resolveCommandWithWsl("M2");
+  const resolved = probeCommandWithWsl("M2").resolution;
   if (!resolved?.args || resolved.args.length < 2) {
     return undefined;
   }
@@ -474,28 +500,33 @@ function resolveWithWsl(): M2ExecutableResolution | undefined {
   };
 }
 
-function resolveCommandWithWsl(
+export function probeCommandWithWsl(
   command: string,
-): CommandExecutableResolution | undefined {
-  const wslPath = findWslExecutable();
+  findWsl: () => string | undefined = findWslExecutable,
+  run: ShellCommandRunner = runShellCommand,
+): CommandProbe {
+  const wslPath = findWsl();
   if (!wslPath) {
-    return undefined;
+    return { timedOut: false };
   }
 
-  const resolved = runShellCommandOutput(
+  const result = run(
     wslPath,
     ["--exec", "sh", "-lc", `command -v ${quoteShellWord(command)}`],
     shellProbeTimeoutMilliseconds,
   );
-  const wslExecutablePath = normalizeShellOutputPath(resolved);
+  const wslExecutablePath = normalizeShellOutputPath(result.output);
   if (!wslExecutablePath || !isUnixAbsolutePath(wslExecutablePath)) {
-    return undefined;
+    return { timedOut: result.timedOut };
   }
 
   return {
-    executablePath: wslPath,
-    source: "WSL",
-    args: ["--exec", wslExecutablePath],
+    resolution: {
+      executablePath: wslPath,
+      source: "WSL",
+      args: ["--exec", wslExecutablePath],
+    },
+    timedOut: false,
   };
 }
 
@@ -538,21 +569,27 @@ function findWslExecutable(): string | undefined {
   ]);
 }
 
-interface ShellCommandResult {
-  output?: string;
-  timedOut: boolean;
-}
+const defaultShellCommandExecutor: ShellCommandExecutor = (
+  executablePath,
+  args,
+  options,
+) => execFileSync(executablePath, args, options);
 
-function runShellCommand(
+export function runShellCommand(
   shellPath: string,
   args: string[],
   timeout?: number,
+  execute: ShellCommandExecutor = defaultShellCommandExecutor,
 ): ShellCommandResult {
   try {
-    const output = execFileSync(shellPath, args, {
+    const output = execute(shellPath, args, {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
       timeout,
+      // execFileSync waits after a timeout until the child actually exits.
+      // SIGTERM can be trapped or ignored, so it does not impose a hard bound
+      // on this synchronous extension-host work.
+      killSignal: "SIGKILL",
     }).trim();
     return { output: output || undefined, timedOut: false };
   } catch (error) {
@@ -576,7 +613,7 @@ function isTimeoutError(error: unknown): boolean {
   const failure = error as
     | (NodeJS.ErrnoException & { signal?: NodeJS.Signals | null })
     | undefined;
-  return failure?.code === "ETIMEDOUT" || failure?.signal === "SIGTERM";
+  return failure?.code === "ETIMEDOUT" || failure?.signal === "SIGKILL";
 }
 
 function normalizeShellOutputPath(

--- a/src/backend/extension.ts
+++ b/src/backend/extension.ts
@@ -5,7 +5,10 @@
 import * as vscode from "vscode";
 import * as repl from "./repl";
 import * as formatter from "./formatter";
-import { createCachedCommandResolver } from "./executablePath";
+import {
+  createCachedCommandResolver,
+  probeConfiguredCommand,
+} from "./executablePath";
 import {
   createLanguageServerController,
   LanguageServerController,
@@ -72,12 +75,24 @@ export function activate(context: vscode.ExtensionContext) {
       .getConfiguration("macaulay2")
       .get<boolean>("enableLanguageServer", true);
 
+  const getConfiguredLanguageServerPath = () =>
+    vscode.workspace
+      .getConfiguration("macaulay2")
+      .get<string>("languageServerPath", "")
+      .trim();
+
+  const languageServerResolver = createCachedCommandResolver(
+    LANGUAGE_SERVER_COMMAND,
+    (command) =>
+      probeConfiguredCommand(getConfiguredLanguageServerPath(), command),
+  );
+
   const controller = createLanguageServerController({
     // Imported lazily: this is what keeps vscode-languageclient out of
     // activation for anyone with no language server installed.
     createClient: async (resolution) =>
       (await import("./client")).createLanguageClient(resolution),
-    resolver: createCachedCommandResolver(LANGUAGE_SERVER_COMMAND),
+    resolver: languageServerResolver,
     isEnabled: isLanguageServerEnabled,
     reportDisabled: () => {
       void vscode.window.showInformationMessage(
@@ -149,6 +164,13 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((e) => {
+      // A new path means the cached resolution is stale, and restart is
+      // already the operation that re-probes and swaps the client.
+      if (e.affectsConfiguration("macaulay2.languageServerPath")) {
+        void controller.restart();
+        return;
+      }
+
       if (!e.affectsConfiguration("macaulay2.enableLanguageServer")) return;
 
       // The controller can start and stop on demand, so apply the setting

--- a/src/backend/extension.ts
+++ b/src/backend/extension.ts
@@ -26,6 +26,10 @@ function isMacaulay2Document(document: vscode.TextDocument): boolean {
   return document.languageId === "macaulay2";
 }
 
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
@@ -63,16 +67,18 @@ export function activate(context: vscode.ExtensionContext) {
     return completions.getWebviewCompletionItems();
   };
 
+  const isLanguageServerEnabled = () =>
+    vscode.workspace
+      .getConfiguration("macaulay2")
+      .get<boolean>("enableLanguageServer", true);
+
   const controller = createLanguageServerController({
     // Imported lazily: this is what keeps vscode-languageclient out of
     // activation for anyone with no language server installed.
     createClient: async (resolution) =>
       (await import("./client")).createLanguageClient(resolution),
     resolver: createCachedCommandResolver(LANGUAGE_SERVER_COMMAND),
-    isEnabled: () =>
-      vscode.workspace
-        .getConfiguration("macaulay2")
-        .get<boolean>("enableLanguageServer", true),
+    isEnabled: isLanguageServerEnabled,
     reportDisabled: () => {
       void vscode.window.showInformationMessage(
         "Macaulay2 Language Server is disabled.",
@@ -85,9 +91,12 @@ export function activate(context: vscode.ExtensionContext) {
     },
     reportStartError: (error) => {
       void vscode.window.showErrorMessage(
-        `Failed to start Macaulay2 Language Server: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
+        `Failed to start Macaulay2 Language Server: ${describeError(error)}`,
+      );
+    },
+    reportStopError: (error) => {
+      void vscode.window.showErrorMessage(
+        `Failed to stop Macaulay2 Language Server: ${describeError(error)}`,
       );
     },
   });
@@ -140,16 +149,16 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((e) => {
-      if (e.affectsConfiguration("macaulay2.enableLanguageServer")) {
-        void vscode.window
-          .showInformationMessage(
-            "Reload the window to apply language server changes.",
-            "Reload",
-          )
-          .then((selection) => {
-            if (selection === "Reload")
-              vscode.commands.executeCommand("workbench.action.reloadWindow");
-          });
+      if (!e.affectsConfiguration("macaulay2.enableLanguageServer")) return;
+
+      // The controller can start and stop on demand, so apply the setting
+      // rather than asking for a window reload.  Turning it back on only
+      // starts the server if one is installed, which is the same thing the
+      // editor events would do.
+      if (isLanguageServerEnabled()) {
+        void controller.start();
+      } else {
+        void controller.stop();
       }
     }),
   );

--- a/src/backend/languageServer.ts
+++ b/src/backend/languageServer.ts
@@ -84,17 +84,24 @@ export function createLanguageServerController(
   };
 
   // Returns whether the language server is ready to be launched, and records a
-  // conclusive "not installed" so the editor events stop asking.  A probe that
-  // merely timed out is not conclusive: the next attempt should look again.
+  // conclusive "not installed" so the editor events stop asking.  A timeout is
+  // kept distinct so restart() never tears down a healthy client because one
+  // fresh lookup was inconclusive.
   const configureResolved = () => {
     const probe = resolver.resolve();
     if (!probe.resolution) {
-      missing = !probe.timedOut;
-      return false;
+      if (probe.timedOut) {
+        missing = false;
+        return "timedOut" as const;
+      }
+
+      missing = true;
+      return "missing" as const;
     }
 
+    missing = false;
     configure(probe.resolution);
-    return true;
+    return "resolved" as const;
   };
 
   const start = () => {
@@ -102,7 +109,7 @@ export function createLanguageServerController(
     if (pending) return pending;
 
     return run(async () => {
-      if (!configureResolved()) return;
+      if (configureResolved() !== "resolved") return;
 
       await client.start();
       started = true;
@@ -126,7 +133,14 @@ export function createLanguageServerController(
       resolver.forget();
       missing = false;
 
-      if (!configureResolved()) {
+      const resolutionState = configureResolved();
+      if (resolutionState === "timedOut") {
+        // A timeout says nothing about whether the executable still exists.
+        // Keep a running client alive, and let the next explicit restart retry.
+        return;
+      }
+
+      if (resolutionState === "missing") {
         // The executable has gone since it was last resolved.  Leaving the old
         // client running while telling the user it was not found would be a
         // lie, and start() would then short-circuit on `started` forever.

--- a/src/backend/languageServer.ts
+++ b/src/backend/languageServer.ts
@@ -38,6 +38,7 @@ export interface LanguageServerControllerOptions {
   reportDisabled(): void;
   reportNotFound(): void;
   reportStartError(error: unknown): void;
+  reportStopError(error: unknown): void;
 }
 
 export interface LanguageServerController {
@@ -61,6 +62,7 @@ export function createLanguageServerController(
     reportDisabled,
     reportNotFound,
     reportStartError,
+    reportStopError,
   } = options;
 
   // Undefined until a resolution succeeds and a client is built for it.
@@ -77,13 +79,16 @@ export function createLanguageServerController(
   // operation is ever in flight and callers can await whatever is running.
   // Errors are reported once and never propagate: every caller discards the
   // result, and an unhandled rejection out of an editor event is not useful.
-  const run = (work: () => Promise<void>): Promise<void> => {
+  const run = (
+    work: () => Promise<void>,
+    report: (error: unknown) => void = reportStartError,
+  ): Promise<void> => {
     const token = ++pendingToken;
     const task = (async () => {
       try {
         await work();
       } catch (error) {
-        reportStartError(error);
+        report(error);
       } finally {
         // A restart that took the slot over while this was settling must keep
         // it, or a concurrent start would see an idle controller.
@@ -169,9 +174,15 @@ export function createLanguageServerController(
     });
   };
 
-  const stop = async () => {
-    if (pending) await pending;
-    await discardClient();
+  // Goes through run() like the others, so it queues behind an in-flight start
+  // instead of tearing the client out from under it, and so a failure to shut
+  // down is reported rather than left as an unhandled rejection.
+  const stop = () => {
+    const previous = pending;
+    return run(async () => {
+      if (previous) await previous;
+      await discardClient();
+    }, reportStopError);
   };
 
   return {

--- a/src/backend/test/extension.test.ts
+++ b/src/backend/test/extension.test.ts
@@ -181,6 +181,20 @@ suite("Extension Tests", function () {
     );
   });
 
+  test("every contributed command is prefixed in the palette", function () {
+    // The README documents them all as "Macaulay2: ...", which is what the
+    // category produces.  Without it a command shows up bare, next to the
+    // prefixed ones.
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(__dirname, "../../package.json"), "utf8"),
+    );
+    const uncategorized = manifest.contributes.commands
+      .filter((command: { category?: string }) => !command.category)
+      .map((command: { command: string }) => command.command);
+
+    assert.deepEqual(uncategorized, []);
+  });
+
   test("matches Macaulay2 identifiers and numeric literals as editor words", function () {
     const configurationSource = fs.readFileSync(
       path.join(__dirname, "../../language-configuration.json"),

--- a/src/backend/test/extension.test.ts
+++ b/src/backend/test/extension.test.ts
@@ -448,6 +448,7 @@ suite("Language Server Controller", function () {
       reportDisabled: () => reported.push("disabled"),
       reportNotFound: () => reported.push("notFound"),
       reportStartError: () => reported.push("startError"),
+      reportStopError: () => reported.push("stopError"),
       ...overrides,
     });
 
@@ -646,6 +647,31 @@ suite("Language Server Controller", function () {
     await harness.controller.start();
     await harness.controller.stop();
 
+    assert.deepEqual(harness.clients[0].calls, ["start", "stop", "dispose"]);
+  });
+
+  test("stop then start builds a fresh client", async function () {
+    // Turning the setting off and back on goes through stop() and start()
+    // rather than a window reload, so the second start has to work.
+    const harness = createHarness([found, found]);
+
+    await harness.controller.start();
+    await harness.controller.stop();
+    await harness.controller.start();
+
+    assert.equal(harness.clients.length, 2);
+    assert.deepEqual(harness.clients[0].calls, ["start", "stop", "dispose"]);
+    assert.deepEqual(harness.clients[1].calls, ["start"]);
+  });
+
+  test("stop queues behind an in-flight start", async function () {
+    const harness = createHarness([found]);
+
+    const starting = harness.controller.start();
+    const stopping = harness.controller.stop();
+    await Promise.all([starting, stopping]);
+
+    assert.equal(harness.clients.length, 1);
     assert.deepEqual(harness.clients[0].calls, ["start", "stop", "dispose"]);
   });
 

--- a/src/backend/test/extension.test.ts
+++ b/src/backend/test/extension.test.ts
@@ -24,7 +24,10 @@ import {
   getM2LaunchConfiguration,
   M2ExecutableResolution,
   normalizeM2LaunchArgs,
+  probeCommandWithWsl,
+  probeWindowsCommandExecutable,
   resolveM2Executable,
+  runShellCommand,
   windowsPathToWslPath,
   wslPathToWindowsPath,
 } from "../executablePath";
@@ -374,6 +377,51 @@ suite("Executable Switcher", function () {
   });
 });
 
+suite("Command Executable Resolution", function () {
+  test("preserves a WSL shell timeout", function () {
+    const result = probeCommandWithWsl(
+      "M2-language-server",
+      () => "C:\\Windows\\System32\\wsl.exe",
+      () => ({ timedOut: true }),
+    );
+
+    assert.deepEqual(result, { timedOut: true });
+  });
+
+  test("propagates a WSL timeout after a conclusive Cygwin miss", function () {
+    const result = probeWindowsCommandExecutable(
+      "M2-language-server",
+      () => ({ timedOut: false }),
+      () => ({ timedOut: true }),
+    );
+
+    assert.deepEqual(result, { timedOut: true });
+  });
+
+  test("uses a hard kill signal for synchronous shell probes", function () {
+    let receivedTimeout: number | undefined;
+    let receivedKillSignal: string | undefined;
+    const timeoutError = Object.assign(new Error("timed out"), {
+      signal: "SIGKILL",
+    });
+
+    const result = runShellCommand(
+      "/path/to/shell",
+      ["-lc", "command -v M2-language-server"],
+      123,
+      (_executablePath, _args, options) => {
+        receivedTimeout = options.timeout;
+        receivedKillSignal = options.killSignal;
+        throw timeoutError;
+      },
+    );
+
+    assert.equal(receivedTimeout, 123);
+    assert.equal(receivedKillSignal, "SIGKILL");
+    assert.deepEqual(result, { timedOut: true });
+  });
+});
+
 suite("Language Server Controller", function () {
   interface FakeClient {
     start(): Thenable<void>;
@@ -503,18 +551,25 @@ suite("Language Server Controller", function () {
     assert.deepEqual(harness.client.calls, ["start"]);
   });
 
-  test("does not cache a probe that timed out", async function () {
-    // A slow login shell is not evidence that the language server is absent,
-    // so the next attempt has to look again rather than inherit the verdict.
+  test("does not repeat a timed-out probe from editor starts", async function () {
+    // Editor events are not a safe retry path for synchronous discovery: a
+    // persistently slow shell would otherwise stall every tab switch.
     const harness = createHarness([timedOut, found]);
 
     await harness.controller.start();
-    assert.deepEqual(harness.client.calls, []);
-
     await harness.controller.start();
+    await harness.controller.start();
+
+    assert.equal(harness.probeCount, 1);
+    assert.deepEqual(harness.client.calls, []);
+    assert.deepEqual(harness.reported, []);
+
+    // The explicit command forgets the cached timeout and tries again.
+    await harness.controller.restart();
 
     assert.equal(harness.probeCount, 2);
     assert.deepEqual(harness.client.calls, ["start"]);
+    assert.deepEqual(harness.reported, []);
   });
 
   test("restart re-probes and starts a server installed since activation", async function () {
@@ -537,6 +592,24 @@ suite("Language Server Controller", function () {
     await harness.controller.restart();
 
     assert.deepEqual(harness.client.calls, ["start", "restart"]);
+  });
+
+  test("restart preserves a running client when resolution times out", async function () {
+    const harness = createHarness([found, timedOut, found]);
+
+    await harness.controller.start();
+    await harness.controller.restart();
+
+    assert.equal(harness.probeCount, 2);
+    assert.deepEqual(harness.client.calls, ["start"]);
+    assert.deepEqual(harness.reported, []);
+
+    // A later explicit restart retries and reuses the still-running client.
+    await harness.controller.restart();
+
+    assert.equal(harness.probeCount, 3);
+    assert.deepEqual(harness.client.calls, ["start", "restart"]);
+    assert.deepEqual(harness.reported, []);
   });
 
   test("restart reports when the language server is disabled", async function () {

--- a/src/backend/test/extension.test.ts
+++ b/src/backend/test/extension.test.ts
@@ -567,6 +567,8 @@ suite("Language Server Controller", function () {
 
     assert.equal(harness.probeCount, 1);
     assert.deepEqual(harness.clients, []);
+    // Silent: nobody asked for a language server by opening a file.
+    assert.deepEqual(harness.reported, []);
   });
 
   test("builds no client when the language server is not installed", async function () {
@@ -654,6 +656,19 @@ suite("Language Server Controller", function () {
     );
     assert.deepEqual(harness.clients[0].calls, ["start", "stop", "dispose"]);
     assert.deepEqual(harness.clients[1].calls, ["start"]);
+  });
+
+  test("restart says so when there is nothing to restart", async function () {
+    // The counterpart to start() staying silent: a restart is an explicit
+    // request, so it gets an answer every time rather than failing quietly.
+    const harness = createHarness([notFound, notFound]);
+
+    await harness.controller.restart();
+    assert.deepEqual(harness.reported, ["notFound"]);
+
+    await harness.controller.restart();
+    assert.deepEqual(harness.reported, ["notFound", "notFound"]);
+    assert.deepEqual(harness.clients, []);
   });
 
   test("restart reports when the language server is disabled", async function () {

--- a/src/backend/test/extension.test.ts
+++ b/src/backend/test/extension.test.ts
@@ -21,6 +21,7 @@ import {
   CommandExecutableResolution,
   CommandProbe,
   createCachedCommandResolver,
+  probeConfiguredCommand,
   getM2ExecutableResolutionDetail,
   getM2LaunchConfiguration,
   M2ExecutableResolution,
@@ -385,6 +386,73 @@ suite("Executable Switcher", function () {
         wslExecutablePath: "/usr/bin/M2",
       }),
       "$(terminal) M2: WSL:/usr/bin/M2",
+    );
+  });
+});
+
+suite("Configured Command Resolution", function () {
+  const autoDetected: CommandProbe = {
+    resolution: {
+      executablePath: "/usr/bin/M2-language-server",
+      source: "PATH",
+    },
+    timedOut: false,
+  };
+
+  test("a configured path wins over auto-detection", function () {
+    let probed = false;
+    const probe = probeConfiguredCommand(
+      "/opt/M2-language-server",
+      "M2-language-server",
+      () => {
+        probed = true;
+        return autoDetected;
+      },
+    );
+
+    assert.deepEqual(probe, {
+      resolution: {
+        executablePath: "/opt/M2-language-server",
+        source: "setting",
+      },
+      timedOut: false,
+    });
+    // Not just overridden afterwards: the probe must not run at all, since it
+    // is the expensive part.
+    assert.equal(probed, false);
+  });
+
+  test("an empty or whitespace setting falls back to auto-detection", function () {
+    for (const configured of [undefined, "", "   "]) {
+      assert.deepEqual(
+        probeConfiguredCommand(
+          configured,
+          "M2-language-server",
+          () => autoDetected,
+        ),
+        autoDetected,
+      );
+    }
+  });
+
+  test("a configured path is trimmed but not otherwise checked", function () {
+    // Taken as given, like macaulay2.executablePath, so a wrong path fails at
+    // startup naming itself rather than silently auto-detecting something else.
+    assert.deepEqual(
+      probeConfiguredCommand(
+        "  /nonexistent/M2-language-server  ",
+        "M2-language-server",
+        () => {
+          throw new Error("should not auto-detect");
+        },
+      ),
+      {
+        resolution: {
+          executablePath: "/nonexistent/M2-language-server",
+          source: "setting",
+        },
+        timedOut: false,
+      },
     );
   });
 });


### PR DESCRIPTION
Fourth follow-up from the review of #29 — the lifecycle and packaging items in §5.

**Stacked on #32**, which is itself stacked on #30. Three independent commits, easiest to read one at a time.

## 1. Give every command the Macaulay2 palette category

`macaulay2.restartLanguageServer` was the only command with a `category`, so the palette showed "Restart Language Server" bare next to "Start M2 REPL". The README already documents all of them as "Macaulay2: …", which is exactly what a category produces — so this makes the palette match the documentation rather than renaming anything. A test asserts no contributed command is missing it.

## 2. Apply `enableLanguageServer` without a window reload

Toggling the setting popped "Reload the window to apply language server changes." The controller can start and stop on demand now, so the handler just does that. Turning it back on only starts a server that is actually installed — the same thing the editor events would do.

`stop()` now goes through `run()` like `start` and `restart`, so it queues behind an in-flight start rather than tearing the client out from under it. It reports through its own hook: routing a failed shutdown through `reportStartError` would have announced it as a failure to *start*.

This also closes review item 5's "double teardown" note. `dispose()` and `deactivate()` both end at the same idempotent `stop()`, so it no longer depends on vscode-languageclient happening to return early from `shutdown()` when the client never started.

## 3. Add `macaulay2.languageServerPath`

M2 has `macaulay2.executablePath` for installs auto-detection can't find; the language server had no equivalent, so anyone whose `M2-language-server` isn't on `PATH` had no way to point at it.

`probeConfiguredCommand` mirrors how `resolveM2Executable` treats a configured M2: the path is taken as given rather than checked, so a wrong one fails at startup naming the path instead of silently falling back to auto-detection and starting something else. That's a deliberate choice and the test says so. Changing the setting restarts the server, since restart is already the operation that drops the cached resolution and swaps in a client built from the new path.

Documented in the README settings table.

## Testing

`npm test` — 86 passing, up from 80 on #32. New: a configured path wins without the probe running at all, empty/whitespace falls back to auto-detection, a configured path is trimmed but not otherwise checked, stop-then-start builds a fresh client, and stop queues behind an in-flight start.

## Not done here

The one §5 item I left is the missing `M2-language-server` warning being a toast on every restart attempt. That is arguably fine as is, and changing it is a UX call rather than a defect — happy to take direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QruFMGMFf7esJacqKJr1ya
