### PR TITLE
Grammar validation coverage and review cleanups

### DIFF
--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -2,5 +2,7 @@ import { defineConfig } from "@vscode/test-cli";
 
 export default defineConfig({
   files: "out/test/**/*.test.js",
+  // Pinned so a VS Code release cannot turn CI red on its own.  Bump it
+  // deliberately, and no lower than the "engines.vscode" floor in package.json.
   version: "1.122.1",
 });

--- a/src/backend/test/grammar.test.ts
+++ b/src/backend/test/grammar.test.ts
@@ -68,9 +68,17 @@ function collectRegexes(node: unknown, where: string): [string, string][] {
   return found;
 }
 
-const grammarFiles = fs
-  .readdirSync(syntaxesDir)
-  .filter((file) => file.endsWith(".json") && file.endsWith("tmLanguage.json"));
+//
+// Taken from the manifest rather than by globbing syntaxes/, so that a grammar
+// added to the extension without being validated here fails a test rather than
+// quietly going unchecked.  It also keeps the templates and m2-tokens.json,
+// which live in the same directory but are not grammars, out of the list.
+//
+const grammarFiles: string[] = JSON.parse(
+  fs.readFileSync(path.join(projectRoot, "package.json"), "utf8"),
+).contributes.grammars.map((grammar: { path: string }) =>
+  path.basename(grammar.path),
+);
 
 //
 // Tokenizing for real is the only way to test a TextMate grammar: the scopes
@@ -140,10 +148,15 @@ async function scopeOf(source: string, text: string): Promise<string> {
 }
 
 suite("TextMate Grammars", () => {
-  test("syntaxes/ contains the grammars the extension contributes", () => {
+  test("every contributed grammar is present in syntaxes/", () => {
+    const missing = grammarFiles.filter(
+      (file) => !fs.existsSync(path.join(syntaxesDir, file)),
+    );
+
+    assert.deepStrictEqual(missing, []);
     assert.ok(
       grammarFiles.includes("macaulay2.tmLanguage.json"),
-      `expected macaulay2.tmLanguage.json in ${syntaxesDir}`,
+      `expected macaulay2.tmLanguage.json among ${grammarFiles.join(", ")}`,
     );
   });
 
@@ -427,6 +440,27 @@ suite("TextMate Grammars", () => {
       assert.strictEqual(inner[1], "string.quoted.other.tripleslash.macaulay2");
     });
 
+    test("//// is an escape, not a terminator", async () => {
+      // Inside a /// string a literal slash is written ////, so a run of four
+      // must not end the string.  Runs of five or more are not handled, which
+      // matches the comment on the rule.
+      const source = "s = /// a //// b /// + 1";
+
+      assert.strictEqual(
+        await scopeOf(source, "////"),
+        "constant.character.escape.macaulay2",
+      );
+      assert.strictEqual(
+        await scopeOf(source, "b"),
+        "string.quoted.other.tripleslash.macaulay2",
+      );
+      // The string really did end at the third ///, so what follows is code.
+      assert.strictEqual(
+        await scopeOf(source, "+"),
+        "keyword.operator.macaulay2",
+      );
+    });
+
     test("TEST /// holds real Macaulay2 code", async () => {
       assert.strictEqual(
         await scopeOf("TEST /// assert(1 == 1) ///", "assert"),
@@ -465,6 +499,11 @@ suite("TextMate Grammars", () => {
       }
     });
 
+    // An unmatched @ runs to the end of the section rather than stopping at the
+    // line, which looks wrong until you try it: SimpleDoc itself rejects an
+    // unbalanced @, so there is no valid document that renders badly because of
+    // it.  Checked against the interpreter, which errors out of
+    // SimpleDoc.m2 rather than treating the text as prose.
     test("an @...@ span embeds Macaulay2", async () => {
       assert.strictEqual(
         await scopeOf(docstring, "TO"),


### PR DESCRIPTION
Last of the follow-ups from the review of #29 — the §8 items. Stacked on #31.

## Validate every contributed grammar

The grammar tests globbed `syntaxes/` with `.endsWith(".json") && .endsWith("tmLanguage.json")` — the first condition is redundant, and it left `codeblock.json`, which the extension contributes, unvalidated. The list now comes from `contributes.grammars` in the manifest, so a grammar added without validation fails a test instead of quietly going unchecked. `codeblock.json` passes all four checks unchanged.

## Cover the //// escape

Nothing tested it. A run of four slashes inside a `///` string must be an escape rather than a terminator, and the string must still end at the next `///`. Both now asserted, along with the fact that what follows is code again.

## Two SimpleDoc edge cases I raised: both are faithful, not bugs

I checked these against the interpreter rather than reasoning about the grammar, and I was wrong to flag them:

- **An unmatched `@` in prose** runs to the end of the section. SimpleDoc rejects an unbalanced `@` outright — M2 errors out of `SimpleDoc.m2` rather than treating the text as prose — so there is no valid document that renders badly because of it.
- **A nested `///` inside an `Example` body** ends the doc string in M2 at exactly the point the grammar ends it. `s = ///raw///` inside a `doc ///` block is already a parse error upstream.

Both now carry a note at the relevant test, so the behavior does not get "fixed" later into something that diverges from the language.

## Document the VS Code pin

An undocumented `version: "1.122.1"` looks like something to delete. The comment says it is pinned so a VS Code release cannot turn CI red on its own, and that it should be bumped deliberately and never below the `engines.vscode` floor. If it was pinned to work around something specific, that is worth saying instead — I did not want to guess.

## A correction

The review's §8 also claimed `.prettierignore` conflicts with `scripts/generate-syntax.js`, since the Prettier Node API does not consult ignore files. **That finding was wrong.** `.prettierignore` is not tracked in this repository — I picked it up from a stray untracked file in my working tree and did not check. There is no conflict: `npm run format` and `npm run update` both format `completionProviders.ts`, and they agree. Apologies for the noise; I have noted it on #29 as well.

## Testing

`npm test` — 72 passing, up from 67 on #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QruFMGMFf7esJacqKJr1ya
